### PR TITLE
FIX : Fixed output path for tools

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -105,7 +105,7 @@ class ToolIndex:
         chunk_overlap: int,
         reindex: bool = False,
         file_hash: Optional[str] = None,
-        is_summary: bool = False,
+        output_file_path: Optional[str] = None,
     ):
         # Make file content hash if not available
         if not file_hash:
@@ -117,13 +117,7 @@ class ToolIndex:
         x2text_adapter_inst: X2TextAdapter = x2text.get_x2text(
             adapter_instance_id=x2text_adapter
         )
-        extract_file_path = None
-        if not is_summary:
-            directory, filename = os.path.split(file_path)
-            extract_file_path: str = os.path.join(
-                directory, "extract", os.path.splitext(filename)[0] + ".txt"
-            )
-        extracted_text = x2text_adapter_inst.process(input_file_path=file_path, output_file_path=extract_file_path)
+        extracted_text = x2text_adapter_inst.process(input_file_path=file_path, output_file_path=output_file_path)
         full_text.append(
             {
                 "section": "full",


### PR DESCRIPTION
## What

Error in output path for tools

## Why

The generated path is not present in tools which throws error. This also needs to be fixed in adapters side.

## How

Instead of building the file path in SDK, we are getting it as function param.

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
