### PR TITLE
runner ubuntu os version updated

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   pypi-publish:
     name: upload release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## What

ubuntu version down graded into ubuntu 20.04 from latest ubuntu 22.04.

python versions availability list: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

## Why

PDM run failed due to python version 3.9.6 arch x64 unavailable in ubuntu 22.04.


## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
