### PR TITLE
fix: Minor error handling in metadata read, log fix in index

### DIFF
--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -281,7 +281,7 @@ class ToolIndex:
                     raise SdkError(f"Error adding nodes to vector db: {e}")
                 self.tool.stream_log("Added nodes to vector db")
 
-        self.tool.stream_log("Done indexing file")
+            self.tool.stream_log("File has been indexed successfully")
         return doc_id
 
     @staticmethod

--- a/src/unstract/sdk/tool/base.py
+++ b/src/unstract/sdk/tool/base.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from abc import ABC, abstractmethod
-from json import loads
+from json import JSONDecodeError, loads
 from pathlib import Path
 from typing import Any, Union
 
@@ -170,6 +170,10 @@ class BaseTool(ABC, StreamMixin):
         try:
             with open(metadata_path, encoding="utf-8") as f:
                 metadata_json = loads(f.read())
+        except JSONDecodeError as e:
+            self.stream_error_and_exit(
+                f"JSON decode error for {metadata_path}: {e}"
+            )
         except FileNotFoundError:
             self.stream_error_and_exit(
                 f"Metadata file not found at {metadata_path}"


### PR DESCRIPTION
## What

- Minor JSON decode error handling in metadata read
- Fixed an incorrect log message in index.py

**NOTE: Since its a minor change, version has not been explicitly bumped - it can go along with** #20

## Why

- Without this error handling, we didn't have context on where the error was coming from / the file that caused it

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

- An incorrect metadata.json returned the expected error with information on the file that caused it

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
