### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report any issues found and help us improve
+title: 'fix: [ISSUE]'
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To reproduce
+Steps to reproduce the behavior.
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Environment details
+ - Version: [e.g. 0.41.2]
+
+## Additional context
+Add any other context about the problem here.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'feat: [ISSUE]'
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Added GitHub standard issue templates for bug report and feature request.

This is NOT same as the PR template.
This should be enough for now to pass check for issue templates in [community standards](https://github.com/Zipstack/unstract-sdk/community).