### PR TITLE
Fix handling of indexing error

### DIFF
--- a/src/unstract/sdk/exceptions.py
+++ b/src/unstract/sdk/exceptions.py
@@ -12,5 +12,6 @@ class SdkError(Exception):
 
 class IndexingError(SdkError):
     def __init__(self, message: str = ""):
-        prefix = "Error with indexing. "
-        super().__init__(prefix + message)
+        if "404" in message:
+            message = "Index not found. Please check vector db adapter settings."
+        super().__init__(message)

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -293,7 +293,7 @@ class ToolIndex:
                     f"Error adding nodes to vector db: {e}",
                     level=LogLevel.ERROR,
                 )
-                raise SdkError(f"Error adding nodes to vector db: {e}")
+                raise IndexingError(str(e)) from e
             self.tool.stream_log("Added nodes to vector db")
 
         self.tool.stream_log("File has been indexed successfully")


### PR DESCRIPTION
## What

- Reuse `CustomException(str(original_err)) from original_err` pattern everywhere
- Add suggestive action for index URL **404 not found** error

## Why

For seamless E2E error propagation. We have already started this, need to follow everywhere.

## How

Since we use raise Exception from e pattern, the original exception traceback is preserved and pushed downstream.

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/234

## Notes on Testing

Downstream is able to retrieve complete error trace.

## Screenshots

See `ERROR middleware.exception` in the logs:

```
{"type": "LOG", "stage": "TOOL_RUN", "level": "ERROR", "log": "Error adding nodes to vector db: Unexpected Response: 404 (Not Found)\nRaw responsecontent:\nb'404 page not found\\n'", "emitted_at": "2024-04-04T10:57:32.190425"}
[04/Apr/2024 10:57:32] ERROR middleware.exception: POST http://frontend.unstract.localhost/api/v1/unstract/mock_org/prompt-studio/index-document/ 400 IndexingAPIError('Index not found. Please check vector db adapter settings.')
Bad Request: /api/v1/unstract/mock_org/prompt-studio/index-document/
[04/Apr/2024 10:57:32] WARNING django.request: Bad Request: /api/v1/unstract/mock_org/prompt-studio/index-document/
172.19.0.3 - - [04/Apr/2024:10:57:32 +0000] "POST /api/v1/unstract/mock_org/prompt-studio/index-document/ HTTP/1.1" 400 132 "http://frontend.unstract.localhost/mock_org/tools/a9206e99-ae6c-45b3-80d2-c07b8d85c3f6" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0"
```

## Checklist

I have read and understood the [Contribution Guidelines]().
