### PR TITLE
Prompt answer fetch doc id filter issue

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -58,9 +58,18 @@ class ToolIndex:
         try:
             self.tool.stream_log(f">>> Querying {vector_db}...")
             self.tool.stream_log(f">>> {doc_id}")
+            doc_id_eq_filter = MetadataFilter.from_dict(
+                {
+                    "key": "doc_id",
+                    "operator": FilterOperator.EQ,
+                    "value": doc_id,
+                }
+            )
+            filters = MetadataFilters(filters=[doc_id_eq_filter])
             q = VectorStoreQuery(
                 query_embedding=embedding_li.get_query_embedding(" "),
                 doc_ids=[doc_id],
+                filters=filters,
                 similarity_top_k=10000,
             )
         except Exception as e:


### PR DESCRIPTION
## What

When Vector DBs like Postgres is used for indexing and when multi-document is uploaded, running a prompt always fetches the same answer for all the documents.

## Why

Indexes created in Postgres/Supabase do not have the column doc_id. The querying for a doc_id needs to be done in the metadata column instead. Explicit filters are to be added for this query to work correctly. Since that was missing, the query always returned the first doc where it finds the match and hence the same answer was returned for all the documents.

## How

Construct the query filter rightly to include the doc_id in the metadata field.

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots
Postgres as VectorDB

![image](https://github.com/Zipstack/unstract-sdk/assets/142381512/f87c2145-d0c0-43cd-82af-989684e25218)

Qdrant as Vector DB

![image](https://github.com/Zipstack/unstract-sdk/assets/142381512/2a9173d2-9328-40bf-9561-b113091ee072)


## Checklist

I have read and understood the [Contribution Guidelines]().
