### PR TITLE
Fix : Prompt service error handling improvement

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.18.1"
+__version__ = "0.18.2"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/prompt.py
+++ b/src/unstract/sdk/prompt.py
@@ -75,7 +75,16 @@ class PromptTool:
             result["status"] = "OK"
             result["structure_output"] = response.text
         except RequestException as e:
-            result["error"] = f"Error occurred: {e}"
+            # Extract error information from the response if available
+            error_message = str(e)
+            content_type = response.headers.get("Content-Type", "").lower()
+            if "application/json" in content_type:
+                response_json = response.json()
+                if "error" in response_json:
+                    error_message = response_json["error"]
+            elif response.text:
+                error_message = response.text
+            result["error"] = error_message
             self.tool.stream_log(
                 f"Error while fetching response for prompt: {result['error']}",
                 level=LogLevel.ERROR,


### PR DESCRIPTION
## What

- Propagate error from `prompt-service` for Content-Type `text/html` and `application/json`

## Why

- To improve error handling

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
