### PR TITLE
Read text file based on mime type

### DIFF
--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -236,7 +236,8 @@ class ToolIndex:
         full_text = []
         extracted_text = ""
         try:
-            if not output_file_path:
+            mime_type = ToolUtils.get_file_mime_type(file_path)
+            if mime_type == "text/plain":
                 with open(file_path, encoding="utf-8") as file:
                     extracted_text = file.read()
             else:


### PR DESCRIPTION
## What

Read text file based on mime type

## Why

Changed logic where we assume that the file is `txt` if `output_file_path` is not present

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
