### PR TITLE
feat: Index key generation fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
     rev: 24.2.0
     hooks:
       - id: black
-        args: [--config=pyproject.toml, -l 80]
+        args: [--config=pyproject.toml, -l 88]
         language: system
         exclude: |
           (?x)^(
@@ -60,7 +60,7 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
-        args: [--max-line-length=80]
+        args: [--max-line-length=88]
         exclude: |
           (?x)^(
               .*migrations/.*\.py|

--- a/pdm.lock
+++ b/pdm.lock
@@ -1428,7 +1428,7 @@ files = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.10.30"
+version = "0.10.31"
 requires_python = "<4.0,>=3.8.1"
 summary = "Interface between LLMs and your data"
 dependencies = [
@@ -1457,8 +1457,8 @@ dependencies = [
     "wrapt",
 ]
 files = [
-    {file = "llama_index_core-0.10.30-py3-none-any.whl", hash = "sha256:2f291ce2975f9dbf0ea87d684d3d8122ce216265f468f32baa2cf4ecfb34ed2a"},
-    {file = "llama_index_core-0.10.30.tar.gz", hash = "sha256:bed3f683606a0b0eb0839677c935a4b57b7bae509a95d380e51c6225630660e0"},
+    {file = "llama_index_core-0.10.31-py3-none-any.whl", hash = "sha256:b894680fa320a94de56d9a933ac7edb646cabf15fe67ae1cf8fa53ac52ab4542"},
+    {file = "llama_index_core-0.10.31.tar.gz", hash = "sha256:66d39d6f253e20311a21e0b98ea386089f099be12f2d23dbe11379a6d908ddf1"},
 ]
 
 [[package]]
@@ -1675,7 +1675,7 @@ files = [
 
 [[package]]
 name = "llama-index-program-openai"
-version = "0.1.5"
+version = "0.1.6"
 requires_python = "<4.0,>=3.8.1"
 summary = "llama-index program openai integration"
 dependencies = [
@@ -1684,8 +1684,8 @@ dependencies = [
     "llama-index-llms-openai<0.2.0,>=0.1.1",
 ]
 files = [
-    {file = "llama_index_program_openai-0.1.5-py3-none-any.whl", hash = "sha256:20b6efa706ac73e4dc5086900fea1ffcb1eb0787c8a6f081669d37da7235aee0"},
-    {file = "llama_index_program_openai-0.1.5.tar.gz", hash = "sha256:c33aa2d2876ad0ff1f9a2a755d4e7d4917240847d0174e7b2d0b8474499bb700"},
+    {file = "llama_index_program_openai-0.1.6-py3-none-any.whl", hash = "sha256:4660b338503537c5edca1e0dab606af6ce372b4f1b597e2833c6b602447c5d8d"},
+    {file = "llama_index_program_openai-0.1.6.tar.gz", hash = "sha256:c6a4980c5ea826088b28b4dee3367edb20221e6d05eb0e05019049190131d772"},
 ]
 
 [[package]]
@@ -2094,7 +2094,7 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.23.2"
+version = "1.23.4"
 requires_python = ">=3.7.1"
 summary = "The official Python library for the openai API"
 dependencies = [
@@ -2107,8 +2107,8 @@ dependencies = [
     "typing-extensions<5,>=4.7",
 ]
 files = [
-    {file = "openai-1.23.2-py3-none-any.whl", hash = "sha256:293a36effde29946eb221040c89c46a4850f2f2e30b37ef09ff6d75226d71b42"},
-    {file = "openai-1.23.2.tar.gz", hash = "sha256:b84aa3005357ceb38f22a269e0e22ee58ce103897f447032d021906f18178a8e"},
+    {file = "openai-1.23.4-py3-none-any.whl", hash = "sha256:ecb72dcb415c8a1f1b6ef2fe32f8fc9a0942727b6365e8caedf916db5c19b180"},
+    {file = "openai-1.23.4.tar.gz", hash = "sha256:72c5a2ab2cda5727b6897f9d079aec16ceccf7dd2e0e0c84a21f7304d5484563"},
 ]
 
 [[package]]
@@ -2303,12 +2303,12 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.2.0"
+version = "4.2.1"
 requires_python = ">=3.8"
-summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 files = [
-    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
-    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
+    {file = "platformdirs-4.2.1-py3-none-any.whl", hash = "sha256:17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1"},
+    {file = "platformdirs-4.2.1.tar.gz", hash = "sha256:031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf"},
 ]
 
 [[package]]
@@ -2792,7 +2792,7 @@ files = [
 
 [[package]]
 name = "referencing"
-version = "0.34.0"
+version = "0.35.0"
 requires_python = ">=3.8"
 summary = "JSON Referencing + Python"
 dependencies = [
@@ -2800,8 +2800,8 @@ dependencies = [
     "rpds-py>=0.7.0",
 ]
 files = [
-    {file = "referencing-0.34.0-py3-none-any.whl", hash = "sha256:d53ae300ceddd3169f1ffa9caf2cb7b769e92657e4fafb23d34b93679116dfd4"},
-    {file = "referencing-0.34.0.tar.gz", hash = "sha256:5773bd84ef41799a5a8ca72dc34590c041eb01bf9aa02632b4a973fb0181a844"},
+    {file = "referencing-0.35.0-py3-none-any.whl", hash = "sha256:8080727b30e364e5783152903672df9b6b091c926a146a759080b62ca3126cd6"},
+    {file = "referencing-0.35.0.tar.gz", hash = "sha256:191e936b0c696d0af17ad7430a3dc68e88bc11be6514f4757dc890f04ab05889"},
 ]
 
 [[package]]
@@ -3583,7 +3583,7 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.25.3"
+version = "20.26.0"
 requires_python = ">=3.7"
 summary = "Virtual Python Environment builder"
 dependencies = [
@@ -3592,8 +3592,8 @@ dependencies = [
     "platformdirs<5,>=3.9.1",
 ]
 files = [
-    {file = "virtualenv-20.25.3-py3-none-any.whl", hash = "sha256:8aac4332f2ea6ef519c648d0bc48a5b1d324994753519919bddbb1aff25a104e"},
-    {file = "virtualenv-20.25.3.tar.gz", hash = "sha256:7bb554bbdfeaacc3349fa614ea5bff6ac300fc7c335e9facf3a3bcfc703f45be"},
+    {file = "virtualenv-20.26.0-py3-none-any.whl", hash = "sha256:0846377ea76e818daaa3e00a4365c018bc3ac9760cbb3544de542885aad61fb3"},
+    {file = "virtualenv-20.26.0.tar.gz", hash = "sha256:ec25a9671a5102c8d2657f62792a27b48f016664c6873f6beed3800008577210"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ lint = [
 ]
 
 [tool.isort]
-line_length = 80
+line_length = 88
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.22.0"
+__version__ = "0.23.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.23.0"
+__version__ = "0.24.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/constants.py
+++ b/src/unstract/sdk/constants.py
@@ -146,7 +146,3 @@ class ToolSettingsKey:
     EMBEDDING_ADAPTER_ID = "embeddingAdapterId"
     VECTOR_DB_ADAPTER_ID = "vectorDbAdapterId"
     X2TEXT_ADAPTER_ID = "x2TextAdapterId"
-
-
-class FileReaderSettings:
-    FILE_READER_CHUNK_SIZE = 8192

--- a/src/unstract/sdk/embedding.py
+++ b/src/unstract/sdk/embedding.py
@@ -17,25 +17,33 @@ class ToolEmbedding:
         self.embedding_adapters = adapters
 
     def get_embedding(self, adapter_instance_id: str) -> BaseEmbedding:
+        """Gets an instance of LlamaIndex's embedding object.
+
+        Args:
+            adapter_instance_id (str): UUID of the embedding adapter
+
+        Returns:
+            BaseEmbedding: Embedding instance
+        """
         try:
             embedding_config_data = ToolAdapter.get_adapter_config(
                 self.tool, adapter_instance_id
             )
             embedding_adapter_id = embedding_config_data.get(Common.ADAPTER_ID)
-            if embedding_adapter_id in self.embedding_adapters:
-                embedding_adapter = self.embedding_adapters[
-                    embedding_adapter_id
-                ][Common.METADATA][Common.ADAPTER]
-                embedding_metadata = embedding_config_data.get(
-                    Common.ADAPTER_METADATA
-                )
-                embedding_adapter_class = embedding_adapter(embedding_metadata)
-                return embedding_adapter_class.get_embedding_instance()
-            else:
+            if embedding_adapter_id not in self.embedding_adapters:
                 raise SdkError(
                     f"Embedding adapter not supported : "
                     f"{embedding_adapter_id}"
                 )
+
+            embedding_adapter = self.embedding_adapters[embedding_adapter_id][
+                Common.METADATA
+            ][Common.ADAPTER]
+            embedding_metadata = embedding_config_data.get(
+                Common.ADAPTER_METADATA
+            )
+            embedding_adapter_class = embedding_adapter(embedding_metadata)
+            return embedding_adapter_class.get_embedding_instance()
         except Exception as e:
             self.tool.stream_log(
                 log=f"Error getting embedding: {e}", level=LogLevel.ERROR

--- a/src/unstract/sdk/embedding.py
+++ b/src/unstract/sdk/embedding.py
@@ -1,11 +1,9 @@
-from typing import Optional
-
 from llama_index.core.embeddings import BaseEmbedding
 from unstract.adapters.constants import Common
 from unstract.adapters.embedding import adapters
 
 from unstract.sdk.adapters import ToolAdapter
-from unstract.sdk.constants import LogLevel, ToolSettingsKey
+from unstract.sdk.constants import LogLevel
 from unstract.sdk.exceptions import SdkError
 from unstract.sdk.tool.base import BaseTool
 
@@ -13,34 +11,17 @@ from unstract.sdk.tool.base import BaseTool
 class ToolEmbedding:
     __TEST_SNIPPET = "Hello, I am Unstract"
 
-    def __init__(self, tool: BaseTool, tool_settings: dict[str, str] = {}):
+    def __init__(self, tool: BaseTool):
         self.tool = tool
         self.max_tokens = 1024 * 16
         self.embedding_adapters = adapters
-        self.embedding_adapter_instance_id = tool_settings.get(
-            ToolSettingsKey.EMBEDDING_ADAPTER_ID
-        )
-        self.embedding_adapter_id: Optional[str] = None
 
-    def get_embedding(
-        self, adapter_instance_id: Optional[str] = None
-    ) -> BaseEmbedding:
-        adapter_instance_id = (
-            adapter_instance_id
-            if adapter_instance_id
-            else self.embedding_adapter_instance_id
-        )
-        if not adapter_instance_id:
-            raise SdkError(
-                f"Adapter_instance_id does not have "
-                f"a valid value: {adapter_instance_id}"
-            )
+    def get_embedding(self, adapter_instance_id: str) -> BaseEmbedding:
         try:
             embedding_config_data = ToolAdapter.get_adapter_config(
                 self.tool, adapter_instance_id
             )
             embedding_adapter_id = embedding_config_data.get(Common.ADAPTER_ID)
-            self.embedding_adapter_id = embedding_adapter_id
             if embedding_adapter_id in self.embedding_adapters:
                 embedding_adapter = self.embedding_adapters[
                     embedding_adapter_id

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional
 
 from llama_index.core import Document
@@ -20,9 +21,7 @@ from unstract.sdk.embedding import ToolEmbedding
 from unstract.sdk.exceptions import IndexingError, SdkError
 from unstract.sdk.tool.base import BaseTool
 from unstract.sdk.utils import ToolUtils
-from unstract.sdk.utils.callback_manager import (
-    CallbackManager as UNCallbackManager,
-)
+from unstract.sdk.utils.callback_manager import CallbackManager as UNCallbackManager
 from unstract.sdk.vector_db import ToolVectorDB
 from unstract.sdk.x2txt import X2Text
 
@@ -32,13 +31,9 @@ class ToolIndex:
         # TODO: Inherit from StreamMixin and avoid using BaseTool
         self.tool = tool
 
-    def get_text_from_index(
-        self, embedding_type: str, vector_db: str, doc_id: str
-    ):
+    def get_text_from_index(self, embedding_type: str, vector_db: str, doc_id: str):
         embedd_helper = ToolEmbedding(tool=self.tool)
-        embedding_li = embedd_helper.get_embedding(
-            adapter_instance_id=embedding_type
-        )
+        embedding_li = embedd_helper.get_embedding(adapter_instance_id=embedding_type)
         embedding_dimension = embedd_helper.get_embedding_length(embedding_li)
 
         vdb_helper = ToolVectorDB(
@@ -139,26 +134,20 @@ class ToolIndex:
         Returns:
             str: A unique ID for the file and indexing arguments combination
         """
-        # Make file content hash if not available
-        if not file_hash:
-            file_hash = ToolUtils.get_hash_from_file(file_path=file_path)
-
         doc_id = self.generate_file_id(
             tool_id=tool_id,
             file_hash=file_hash,
             vector_db=vector_db,
             embedding=embedding_type,
             x2text=x2text_adapter,
-            chunk_size=chunk_size,
-            chunk_overlap=chunk_overlap,
+            chunk_size=str(chunk_size),
+            chunk_overlap=str(chunk_overlap),
         )
         self.tool.stream_log(f"Checking if doc_id {doc_id} exists")
 
         # Get embedding instance
         embedd_helper = ToolEmbedding(tool=self.tool)
-        embedding_li = embedd_helper.get_embedding(
-            adapter_instance_id=embedding_type
-        )
+        embedding_li = embedd_helper.get_embedding(adapter_instance_id=embedding_type)
         embedding_dimension = embedd_helper.get_embedding_length(embedding_li)
 
         # Get vectorDB instance
@@ -255,26 +244,20 @@ class ToolIndex:
             parser = SimpleNodeParser.from_defaults(
                 chunk_size=len(documents[0].text) + 10, chunk_overlap=0
             )
-            nodes = parser.get_nodes_from_documents(
-                documents, show_progress=True
-            )
+            nodes = parser.get_nodes_from_documents(documents, show_progress=True)
             node = nodes[0]
             node.embedding = embedding_li.get_query_embedding(" ")
             vector_db_li.add(nodes=[node])
             self.tool.stream_log("Added node to vector db")
         else:
-            storage_context = StorageContext.from_defaults(
-                vector_store=vector_db_li
-            )
+            storage_context = StorageContext.from_defaults(vector_store=vector_db_li)
             parser = SimpleNodeParser.from_defaults(
                 chunk_size=chunk_size, chunk_overlap=chunk_overlap
             )
 
             # Set callback_manager to collect Usage stats
             callback_manager = UNCallbackManager.set_callback_manager(
-                platform_api_key=self.tool.get_env_or_die(
-                    ToolEnv.PLATFORM_API_KEY
-                ),
+                platform_api_key=self.tool.get_env_or_die(ToolEnv.PLATFORM_API_KEY),
                 embedding=embedding_li,
             )
 
@@ -302,39 +285,45 @@ class ToolIndex:
     def generate_file_id(
         self,
         tool_id: str,
-        file_hash: str,
         vector_db: str,
         embedding: str,
         x2text: str,
         chunk_size: str,
         chunk_overlap: str,
+        file_path: Optional[str] = None,
+        file_hash: Optional[str] = None,
     ) -> str:
         """Generates a unique ID useful for identifying files during indexing.
 
         Args:
             tool_id (str): Unique ID of the tool or workflow
-            file_hash (str): Hash of the file contents
             vector_db (str): UUID of the vector DB adapter
             embedding (str): UUID of the embedding adapter
             x2text (str): UUID of the X2Text adapter
             chunk_size (str): Chunk size for indexing
             chunk_overlap (str): Chunk overlap for indexing
+            file_path (Optional[str]): Path to the file that needs to be indexed.
+                Defaults to None. One of file_path or file_hash needs to be specified.
+            file_hash (Optional[str], optional): SHA256 hash of the file.
+                Defaults to None. If None, the hash is generated with file_path.
 
         Returns:
             str: Key representing unique ID for a file
         """
+        if not file_path and not file_hash:
+            raise ValueError("One of `file_path` or `file_hash` need to be provided")
+
+        if not file_hash:
+            file_hash = ToolUtils.get_hash_from_file(file_path=file_path)
+
         index_key = {
             "tool_id": tool_id,
             "file_hash": file_hash,
-            "vector_db_config": ToolAdapter.get_adapter_config(
-                self.tool, vector_db
-            ),
-            "embedding_config": ToolAdapter.get_adapter_config(
-                self.tool, embedding
-            ),
+            "vector_db_config": ToolAdapter.get_adapter_config(self.tool, vector_db),
+            "embedding_config": ToolAdapter.get_adapter_config(self.tool, embedding),
             "x2text_config": ToolAdapter.get_adapter_config(self.tool, x2text),
             "chunk_size": chunk_size,
             "chunk_overlap": chunk_overlap,
         }
-        hashed_index_key = ToolUtils.hash_str(ToolUtils.json_to_str(index_key))
+        hashed_index_key = ToolUtils.hash_str(json.dumps(index_key, sort_keys=True))
         return hashed_index_key

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -136,12 +136,13 @@ class ToolIndex:
         """
         doc_id = self.generate_file_id(
             tool_id=tool_id,
-            file_hash=file_hash,
             vector_db=vector_db,
             embedding=embedding_type,
             x2text=x2text_adapter,
             chunk_size=str(chunk_size),
             chunk_overlap=str(chunk_overlap),
+            file_path=file_path,
+            file_hash=file_hash,
         )
         self.tool.stream_log(f"Checking if doc_id {doc_id} exists")
 
@@ -316,6 +317,9 @@ class ToolIndex:
         if not file_hash:
             file_hash = ToolUtils.get_hash_from_file(file_path=file_path)
 
+        # Whole adapter config is used currently even though it contains some keys
+        # which might not be relevant to indexing. This is easier for now than
+        # marking certain keys of the adapter config as necessary.
         index_key = {
             "tool_id": tool_id,
             "file_hash": file_hash,
@@ -325,5 +329,7 @@ class ToolIndex:
             "chunk_size": chunk_size,
             "chunk_overlap": chunk_overlap,
         }
+        # JSON keys are sorted to ensure that the same key gets hashed even in
+        # case where the fields are reordered.
         hashed_index_key = ToolUtils.hash_str(json.dumps(index_key, sort_keys=True))
         return hashed_index_key

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -9,7 +9,7 @@ from unstract.adapters.llm import adapters
 from unstract.adapters.llm.llm_adapter import LLMAdapter
 
 from unstract.sdk.adapters import ToolAdapter
-from unstract.sdk.constants import LogLevel, ToolSettingsKey
+from unstract.sdk.constants import LogLevel
 from unstract.sdk.exceptions import SdkError
 from unstract.sdk.tool.base import BaseTool
 from unstract.sdk.utils.callback_manager import (
@@ -24,12 +24,8 @@ class ToolLLM:
 
     json_regex = re.compile(r"\{(?:.|\n)*\}")
 
-    def __init__(
-        self,
-        tool: BaseTool,
-        tool_settings: dict[str, str] = {},
-    ):
-        """
+    def __init__(self, tool: BaseTool):
+        """ToolLLM constructor.
 
         Notes:
             - "Azure OpenAI" : Environment variables required
@@ -42,9 +38,7 @@ class ToolLLM:
         self.tool = tool
         self.max_tokens = 1024 * 4
         self.llm_adapters = adapters
-        self.llm_adapter_instance_id = tool_settings.get(
-            ToolSettingsKey.LLM_ADAPTER_ID
-        )
+        self.llm_config_data: Optional[dict[str, Any]] = None
 
     @classmethod
     def run_completion(
@@ -90,47 +84,35 @@ class ToolLLM:
                 time.sleep(5)
         return None
 
-    def get_llm(self, adapter_instance_id: Optional[str] = None) -> LLM:
+    def get_llm(self, adapter_instance_id: str) -> LLM:
         """Returns the LLM object for the tool.
 
         Returns:
             LLM: The LLM object for the tool.
             (llama_index.llms.base.LLM)
         """
-        adapter_instance_id = (
-            adapter_instance_id
-            if adapter_instance_id
-            else self.llm_adapter_instance_id
-        )
-        # Support for get_llm using adapter_instance_id
-        if adapter_instance_id is not None:
-            try:
-                llm_config_data = ToolAdapter.get_adapter_config(
-                    self.tool, adapter_instance_id
-                )
-                llm_adapter_id = llm_config_data.get(Common.ADAPTER_ID)
-                if llm_adapter_id in self.llm_adapters:
-                    llm_adapter = self.llm_adapters[llm_adapter_id][
-                        Common.METADATA
-                    ][Common.ADAPTER]
-                    llm_metadata = llm_config_data.get(Common.ADAPTER_METADATA)
-                    llm_adapter_class: LLMAdapter = llm_adapter(llm_metadata)
-                    llm_instance: LLM = llm_adapter_class.get_llm_instance()
-                    return llm_instance
-                else:
-                    raise SdkError(
-                        f"LLM adapter not supported : " f"{llm_adapter_id}"
-                    )
-            except Exception as e:
-                self.tool.stream_log(
-                    log=f"Unable to get llm instance: {e}", level=LogLevel.ERROR
-                )
-                raise SdkError(f"Error getting llm instance: {e}")
-        else:
-            raise SdkError(
-                f"Adapter_instance_id does not have "
-                f"a valid value: {adapter_instance_id}"
+        try:
+            llm_config_data = ToolAdapter.get_adapter_config(
+                self.tool, adapter_instance_id
             )
+            llm_adapter_id = llm_config_data.get(Common.ADAPTER_ID)
+            if llm_adapter_id in self.llm_adapters:
+                llm_adapter = self.llm_adapters[llm_adapter_id][
+                    Common.METADATA
+                ][Common.ADAPTER]
+                llm_metadata = llm_config_data.get(Common.ADAPTER_METADATA)
+                llm_adapter_class: LLMAdapter = llm_adapter(llm_metadata)
+                llm_instance: LLM = llm_adapter_class.get_llm_instance()
+                return llm_instance
+            else:
+                raise SdkError(
+                    f"LLM adapter not supported : " f"{llm_adapter_id}"
+                )
+        except Exception as e:
+            self.tool.stream_log(
+                log=f"Unable to get llm instance: {e}", level=LogLevel.ERROR
+            )
+            raise SdkError(f"Error getting llm instance: {e}")
 
     def get_max_tokens(self, reserved_for_output: int = 0) -> int:
         """Returns the maximum number of tokens that can be used for the LLM.

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -96,18 +96,18 @@ class ToolLLM:
                 self.tool, adapter_instance_id
             )
             llm_adapter_id = llm_config_data.get(Common.ADAPTER_ID)
-            if llm_adapter_id in self.llm_adapters:
-                llm_adapter = self.llm_adapters[llm_adapter_id][
-                    Common.METADATA
-                ][Common.ADAPTER]
-                llm_metadata = llm_config_data.get(Common.ADAPTER_METADATA)
-                llm_adapter_class: LLMAdapter = llm_adapter(llm_metadata)
-                llm_instance: LLM = llm_adapter_class.get_llm_instance()
-                return llm_instance
-            else:
+            if llm_adapter_id not in self.llm_adapters:
                 raise SdkError(
                     f"LLM adapter not supported : " f"{llm_adapter_id}"
                 )
+
+            llm_adapter = self.llm_adapters[llm_adapter_id][
+                Common.METADATA
+            ][Common.ADAPTER]
+            llm_metadata = llm_config_data.get(Common.ADAPTER_METADATA)
+            llm_adapter_class: LLMAdapter = llm_adapter(llm_metadata)
+            llm_instance: LLM = llm_adapter_class.get_llm_instance()
+            return llm_instance
         except Exception as e:
             self.tool.stream_log(
                 log=f"Unable to get llm instance: {e}", level=LogLevel.ERROR

--- a/src/unstract/sdk/utils/tool_utils.py
+++ b/src/unstract/sdk/utils/tool_utils.py
@@ -5,8 +5,6 @@ from typing import Any
 
 import magic
 
-from unstract.sdk.constants import FileReaderSettings
-
 
 class ToolUtils:
     """Class containing utility methods."""
@@ -38,18 +36,24 @@ class ToolUtils:
             raise ValueError(f"Unsupported hash_method: {hash_method}")
 
     @staticmethod
-    def get_hash_from_file(file_path: str):
-        hashes = []
-        chunk_size = FileReaderSettings.FILE_READER_CHUNK_SIZE
+    def get_hash_from_file(file_path: str) -> str:
+        """Computes the hash for a file.
 
-        with open(file_path, "rb") as f:
-            while True:
-                chunk = f.read(chunk_size)
-                if not chunk:
-                    break  # End of file
-                hashes.append(ToolUtils.hash_str(chunk))
-        hash_value = ToolUtils.hash_str("".join(hashes))
-        return hash_value
+        Uses sha256 to compute the file hash through a buffered read.
+
+        Args:
+            file_path (str): Path to file that needs to be hashed
+
+        Returns:
+            str: SHA256 hash of the file
+        """
+        h = sha256()
+        b = bytearray(128 * 1024)
+        mv = memoryview(b)
+        with open(file_path, "rb", buffering=0) as f:
+            while n := f.readinto(mv):
+                h.update(mv[:n])
+        return str(h.hexdigest())
 
     @staticmethod
     def load_json(file_to_load: str) -> dict[str, Any]:

--- a/src/unstract/sdk/vector_db.py
+++ b/src/unstract/sdk/vector_db.py
@@ -10,7 +10,7 @@ from unstract.adapters.vectordb import adapters
 from unstract.adapters.vectordb.constants import VectorDbConstants
 
 from unstract.sdk.adapters import ToolAdapter
-from unstract.sdk.constants import LogLevel, ToolEnv, ToolSettingsKey
+from unstract.sdk.constants import LogLevel, ToolEnv
 from unstract.sdk.exceptions import SdkError
 from unstract.sdk.platform import PlatformHelper
 from unstract.sdk.tool.base import BaseTool
@@ -21,12 +21,9 @@ logger = logging.getLogger(__name__)
 class ToolVectorDB:
     """Class to handle VectorDB for Unstract Tools."""
 
-    def __init__(self, tool: BaseTool, tool_settings: dict[str, str] = {}):
+    def __init__(self, tool: BaseTool):
         self.tool = tool
         self.vector_db_adapters = adapters
-        self.vector_db_adapter_instance_id = tool_settings.get(
-            ToolSettingsKey.VECTOR_DB_ADAPTER_ID
-        )
 
     def __get_org_id(self) -> str:
         platform_helper = PlatformHelper(
@@ -45,49 +42,36 @@ class ToolVectorDB:
     def get_vector_db(
         self, adapter_instance_id: str, embedding_dimension: int
     ) -> Union[BasePydanticVectorStore, VectorStore]:
-        adapter_instance_id = (
-            adapter_instance_id
-            if adapter_instance_id
-            else self.vector_db_adapter_instance_id
-        )
-        if adapter_instance_id is not None:
-            try:
-                vector_db_config = ToolAdapter.get_adapter_config(
-                    self.tool, adapter_instance_id
-                )
-                vector_db_adapter_id = vector_db_config.get(Common.ADAPTER_ID)
-                if vector_db_adapter_id in self.vector_db_adapters:
-                    vector_db_adapter = self.vector_db_adapters[
-                        vector_db_adapter_id
-                    ][Common.METADATA][Common.ADAPTER]
-                    vector_db_metadata = vector_db_config.get(
-                        Common.ADAPTER_METADATA
-                    )
-                    org = self.__get_org_id()
-                    # Adding the collection prefix and embedding type
-                    # to the metadata
-                    vector_db_metadata[VectorDbConstants.VECTOR_DB_NAME] = org
-                    vector_db_metadata[
-                        VectorDbConstants.EMBEDDING_DIMENSION
-                    ] = embedding_dimension
-
-                    vector_db_adapter_class = vector_db_adapter(
-                        vector_db_metadata
-                    )
-                    return vector_db_adapter_class.get_vector_db_instance()
-                else:
-                    raise SdkError(
-                        f"VectorDB adapter not supported : "
-                        f"{vector_db_adapter_id}"
-                    )
-            except Exception as e:
-                self.tool.stream_log(
-                    log=f"Unable to get vector_db {adapter_instance_id}: {e}",
-                    level=LogLevel.ERROR,
-                )
-                raise SdkError(f"Error getting vectorDB instance: {e}")
-        else:
-            raise SdkError(
-                f"Adapter_instance_id does not have "
-                f"a valid value: {adapter_instance_id}"
+        try:
+            vector_db_config = ToolAdapter.get_adapter_config(
+                self.tool, adapter_instance_id
             )
+            vector_db_adapter_id = vector_db_config.get(Common.ADAPTER_ID)
+            if vector_db_adapter_id in self.vector_db_adapters:
+                vector_db_adapter = self.vector_db_adapters[
+                    vector_db_adapter_id
+                ][Common.METADATA][Common.ADAPTER]
+                vector_db_metadata = vector_db_config.get(
+                    Common.ADAPTER_METADATA
+                )
+                org = self.__get_org_id()
+                # Adding the collection prefix and embedding type
+                # to the metadata
+                vector_db_metadata[VectorDbConstants.VECTOR_DB_NAME] = org
+                vector_db_metadata[
+                    VectorDbConstants.EMBEDDING_DIMENSION
+                ] = embedding_dimension
+
+                vector_db_adapter_class = vector_db_adapter(vector_db_metadata)
+                return vector_db_adapter_class.get_vector_db_instance()
+            else:
+                raise SdkError(
+                    f"VectorDB adapter not supported : "
+                    f"{vector_db_adapter_id}"
+                )
+        except Exception as e:
+            self.tool.stream_log(
+                log=f"Unable to get vector_db {adapter_instance_id}: {e}",
+                level=LogLevel.ERROR,
+            )
+            raise SdkError(f"Error getting vectorDB instance: {e}")

--- a/src/unstract/sdk/x2txt.py
+++ b/src/unstract/sdk/x2txt.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta
-from typing import Optional
 
 from unstract.adapters.constants import Common
 from unstract.adapters.x2text import adapters
@@ -8,6 +7,7 @@ from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
 from unstract.sdk.adapters import ToolAdapter
 from unstract.sdk.constants import LogLevel
+from unstract.sdk.exceptions import SdkError
 from unstract.sdk.tool.base import BaseTool
 
 
@@ -16,7 +16,7 @@ class X2Text(metaclass=ABCMeta):
         self.tool = tool
         self.x2text_adapters = adapters
 
-    def get_x2text(self, adapter_instance_id: str) -> Optional[X2TextAdapter]:
+    def get_x2text(self, adapter_instance_id: str) -> X2TextAdapter:
         try:
             x2text_config = ToolAdapter.get_adapter_config(
                 self.tool, adapter_instance_id
@@ -49,4 +49,4 @@ class X2Text(metaclass=ABCMeta):
                 log=f"Unable to get x2text adapter {adapter_instance_id}: {e}",
                 level=LogLevel.ERROR,
             )
-            return None
+            raise SdkError(f"Error getting vectorDB instance: {e}")


### PR DESCRIPTION
## What

- Index key generation fixed - hash a dict of values instead of combining UUIDs
- File hash function is optimized
- Minor: Dead code removed in wrappers of adapters
- Version bumped to 0.23.0, lockfile updated
- MINOR: Some error handling code around vector DB / embedding was removed
- MINOR: Increased line length limit to precommit hooks to 88

## Why

- File hashing was incorrect - hashes were appended while in reality they should be XOR-ed
- Previous index key gen logic did not allow adapter updates to be reflected during reindex of a document, since they were based on UUIDs
- Error handling code removal reason [here](https://github.com/Zipstack/unstract-sdk/pull/42#discussion_r1579230070)

## How

- New index key gen logic uses the adapter configurations and hash them altogether

## Can this PR break any existing features. If yes please list of possible items. If no please explain why. (PS: Admins do not merge the PR without this section filled)
Yes, since there's an update in the index key generated - all old index keys would be invalid. In order to perform a clean up - a migration has been added in https://github.com/Zipstack/unstract/pull/289


## Related PRs
- [Unstract PR](https://github.com/Zipstack/unstract/pull/289) that contains the necessary migrations

## Notes on Testing

- Tested them along with other changes in unstract, index key generated as sha 256 hash.
- Adapter changes causes index to be generated again

## Screenshots

![image](https://github.com/Zipstack/unstract-sdk/assets/117059509/ca1d2593-f358-4d73-9e0b-855f6ac02b63)
![image](https://github.com/Zipstack/unstract-sdk/assets/117059509/debc45e8-8140-494f-82e9-993ebb9c0b5e)


## Checklist

I have read and understood the [Contribution Guidelines]().
