### PR TITLE
fix: Minor log enhancement - prefix for openAI errors

### DIFF
--- a/src/unstract/sdk/exceptions.py
+++ b/src/unstract/sdk/exceptions.py
@@ -13,7 +13,7 @@ class SdkError(Exception):
 class IndexingError(SdkError):
     def __init__(self, message: str = ""):
         if "404" in message:
-            message = "Index not found. Please check vector db adapter settings."
+            message = "Index not found. Please check vector DB settings."
         super().__init__(message)
 
 

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -70,9 +70,10 @@ class ToolLLM:
             return {"response": response}
         # TODO: Handle for all LLM providers
         except OpenAIAPIError as e:
-            msg = e.message
+            msg = "OpenAI error: "
+            msg += e.message
             if hasattr(e, "body") and "message" in e.body:
-                msg = e.body["message"]
+                msg += e.body["message"]
             if isinstance(e, OpenAIRateLimitError):
                 raise RateLimitError(msg)
             raise ToolLLMError(msg) from e


### PR DESCRIPTION
## What

- Added a log prefix for openAI errors
- Minor update on the 404 Index error -> removed reference to adapter since its not a UI exposed term
- Version is not bumped since `0.25.1` is not released yet

## Why

- Not including context on where the error is from in such cases
![image](https://github.com/Zipstack/unstract-sdk/assets/117059509/83889ea9-5a65-4c62-8188-3a681541a39f)


## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
