### PR TITLE
Bump Anthropic LLM adapter version

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "lint", "test"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:0329d6195f52850f2fdc8bd308cb3a6b129f2ec32e55500b4d1c4e7d75c4de2b"
+content_hash = "sha256:ff3261c18de4265865867b05c7b1a080084eafbf6ae7fb5a56086b62588d1fa0"
 
 [[package]]
 name = "aiohttp"
@@ -94,7 +94,7 @@ files = [
 
 [[package]]
 name = "anthropic"
-version = "0.17.0"
+version = "0.23.1"
 requires_python = ">=3.7"
 summary = "The official Python library for the anthropic API"
 dependencies = [
@@ -107,8 +107,8 @@ dependencies = [
     "typing-extensions<5,>=4.7",
 ]
 files = [
-    {file = "anthropic-0.17.0-py3-none-any.whl", hash = "sha256:e582635d65d940cd0d957631d548aa2d8add4f261556bf53f8c1f6e5fa6082fd"},
-    {file = "anthropic-0.17.0.tar.gz", hash = "sha256:6f1958e7ffd706a19741260d6dfef3fd9af07d31a57b837792331b4ba0aa067c"},
+    {file = "anthropic-0.23.1-py3-none-any.whl", hash = "sha256:6dc5779dae83a5834864f4a4af0166c972b70f4cb8fd2765e1558282cc6d6242"},
+    {file = "anthropic-0.23.1.tar.gz", hash = "sha256:9325103702cbc96bb09d1b58c36bde75c726f6a01029fb4d85f41ebba07e9066"},
 ]
 
 [[package]]
@@ -1549,16 +1549,16 @@ files = [
 
 [[package]]
 name = "llama-index-llms-anthropic"
-version = "0.1.5"
-requires_python = ">=3.8.1,<4.0"
+version = "0.1.11"
+requires_python = "<4.0,>=3.8.1"
 summary = "llama-index llms anthropic integration"
 dependencies = [
-    "anthropic<0.18.0,>=0.17.0",
+    "anthropic<0.24.0,>=0.23.1",
     "llama-index-core<0.11.0,>=0.10.1",
 ]
 files = [
-    {file = "llama_index_llms_anthropic-0.1.5-py3-none-any.whl", hash = "sha256:4884fa25c07073baec248aa07b843c29c969a8515dec58abda86cd8e5e15f44f"},
-    {file = "llama_index_llms_anthropic-0.1.5.tar.gz", hash = "sha256:33d4622d7833d8ca326cd57e903ad50da3efbf7ae92bdf70b37b4b5419d8c91f"},
+    {file = "llama_index_llms_anthropic-0.1.11-py3-none-any.whl", hash = "sha256:488964147907058c81f5c272830401fa17da3bfe0a6688db87ec2538d5887491"},
+    {file = "llama_index_llms_anthropic-0.1.11.tar.gz", hash = "sha256:7ec7008b54076cbb846cc3d4f5811354778148d75562f92f83e5622cde7657b9"},
 ]
 
 [[package]]
@@ -3541,7 +3541,7 @@ files = [
 
 [[package]]
 name = "unstract-adapters"
-version = "0.15.0"
+version = "0.15.1"
 requires_python = "<3.12,>=3.9"
 summary = "Unstract interface for LLMs, Embeddings and VectorDBs"
 dependencies = [
@@ -3550,7 +3550,7 @@ dependencies = [
     "llama-index-embeddings-azure-openai==0.1.6",
     "llama-index-embeddings-azure-openai==0.1.6",
     "llama-index-embeddings-google==0.1.4",
-    "llama-index-llms-anthropic==0.1.5",
+    "llama-index-llms-anthropic==0.1.11",
     "llama-index-llms-anyscale==0.1.3",
     "llama-index-llms-azure-openai==0.1.5",
     "llama-index-llms-mistralai==0.1.10",
@@ -3568,8 +3568,8 @@ dependencies = [
     "singleton-decorator~=1.0.0",
 ]
 files = [
-    {file = "unstract_adapters-0.15.0-py3-none-any.whl", hash = "sha256:7ed9a1126b091e2c7117203b3f3e850448dfc50e330aa0fbff83131b17b4bcc0"},
-    {file = "unstract_adapters-0.15.0.tar.gz", hash = "sha256:8055202b1cd706835cc8fc62fc7b57b81adbd64c64bc3014e4eb90d6268a9e6f"},
+    {file = "unstract_adapters-0.15.1-py3-none-any.whl", hash = "sha256:c4e4afe661ce363bc6842626fa1d5a402cb5146db2980a3d20f6e70c6a218f1f"},
+    {file = "unstract_adapters-0.15.1.tar.gz", hash = "sha256:279e1e4c80b5f399a219ba63edf4cf5d640342f1b2e779b6c16b004cc7bfc802"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "python-magic~=0.4.27",
     "python-dotenv==1.0.0",
     # LLM Triad
-    "unstract-adapters~=0.15.0",
+    "unstract-adapters~=0.15.1",
     "llama-index==0.10.28",
     "tiktoken~=0.4.0",
     "transformers==4.37.0",

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.26.0"
+__version__ = "0.26.1"
 
 
 def get_sdk_version():


### PR DESCRIPTION
## What

- Bump unstract-adapters to **0.15.1**
- Bump sdk to **0.26.1**

## Why

Anthropic LLM adapter function calling is only available in unstract-adapters **0.15.1** or above. This is required for multi-document chat agentic workflows. 

## Relevant Docs

- Diff at https://github.com/run-llama/llama_index/commits/v0.10.36/llama-index-integrations/llms/llama-index-llms-anthropic.
- Release history at https://pypi.org/project/llama-index-llms-anthropic/0.1.11/#history.  
  We need changes from Mar 14 (0.1.6) onwards.

## Notes on Testing

- [**PASSED**] Test connection for Anthropic LLM adapter
- [**PASSED**] Prompt execution with Anthropic LLM in corresponding profile manager

## Checklist

I have read and understood the [Contribution Guidelines]().
