### PR TITLE
fix: OpenAI error log fix

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.27.0"
+__version__ = "0.27.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -71,9 +71,10 @@ class LLM:
         # TODO: Handle for all LLM providers
         except OpenAIAPIError as e:
             msg = "OpenAI error: "
-            msg += e.message
             if hasattr(e, "body") and "message" in e.body:
                 msg += e.body["message"]
+            else:
+                msg += e.message
             if isinstance(e, OpenAIRateLimitError):
                 raise RateLimitError(msg)
             raise LLMError(msg) from e


### PR DESCRIPTION
## What

- Minor exception handling fix for OpenAI related log messages
- Version bumped to 0.27.1

## Why

- OpenAI related errors were not handled correctly - they included messages of the below format where the user friendly message was appended at the end unnecessarily
```
unstract.sdk.exceptions.LLMError: OpenAI error: Error code: 400 - {'error': {'message': "This model's maximum context length is 131072 tokens. However, your messages resulted in 345793 tokens. Please reduce the length of the messages.", 'type': 'invalid_request_error', 'param': 'messages', 'code': 'context_length_exceeded'}}This model's maximum context length is 131072 tokens. However, your messages resulted in 345793 tokens. Please reduce the length of the messages.
```



## Related Issues or PRs

- #46 


## Notes on Testing

- No explicit testing performed, however this should help avoid repeating the message in some OpenAI errors

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
