### PR TITLE
[FIX] Fixing timeout for prompt execution

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.31.0"
+__version__ = "0.31.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -401,7 +401,7 @@ class Index:
         )
 
     @deprecated(
-        "Deprecated class and method. Use Index and query_texy_from_index() instead"
+        "Deprecated class and method. Use Index and query_index() instead"
     )
     def get_text_from_index(
         self, embedding_type: str, vector_db: str, doc_id: str

--- a/src/unstract/sdk/prompt.py
+++ b/src/unstract/sdk/prompt.py
@@ -68,7 +68,7 @@ class PromptTool:
         headers: dict[str, str] = {"Authorization": f"Bearer {self.bearer_token}"}
         response: Response = Response()
         try:
-            response = requests.post(url, json=payload, headers=headers, timeout=600)
+            response = requests.post(url, json=payload, headers=headers)
             response.raise_for_status()
             result["status"] = "OK"
             result["structure_output"] = response.text

--- a/src/unstract/sdk/prompt.py
+++ b/src/unstract/sdk/prompt.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Optional
 
 import requests
-from requests import ConnectionError, RequestException, Response, Timeout
+from requests import ConnectionError, RequestException, Response
 
 from unstract.sdk.constants import LogLevel, PromptStudioKeys, ToolEnv
 from unstract.sdk.helper import SdkHelper
@@ -75,13 +75,6 @@ class PromptTool:
         except ConnectionError as connect_err:
             msg = "Unable to connect to prompt service. Please contact admin."
             self._stringify_and_stream_err(connect_err, msg)
-            result["error"] = msg
-        except Timeout as time_out:
-            msg = (
-                "Request to run prompt has timed out. "
-                "Probable causes might be connectivity issues in LLMs."
-            )
-            self._stringify_and_stream_err(time_out, msg)
             result["error"] = msg
         except RequestException as e:
             # Extract error information from the response if available


### PR DESCRIPTION
## What
This PR removes the max timeout hardcoded. And, unifies the timeout value set in the adapters/backend.
TO DO : To check the behaviour when the timeout handled by Llama index and take care of thhis in SDKs if needed. 
...

## Why
Timeout happens if the prompt executes more than 10min.

...

## How
Removing the hardcoded timeout value.
...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
