### PR TITLE
Change top_k value

### DIFF
--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -23,6 +23,10 @@ from unstract.sdk.vector_db import VectorDB
 from unstract.sdk.x2txt import X2Text
 
 
+class Constants:
+    TOP_K = 5
+
+
 class Index:
     def __init__(self, tool: BaseTool):
         # TODO: Inherit from StreamMixin and avoid using BaseTool
@@ -73,7 +77,7 @@ class Index:
                     query_embedding=embedding.get_query_embedding(" "),
                     doc_ids=[doc_id],
                     filters=filters,
-                    similarity_top_k=10000,
+                    similarity_top_k=Constants.TOP_K,
                 )
             except Exception as e:
                 self.tool.stream_log(
@@ -400,9 +404,7 @@ class Index:
             output_file_path=output_file_path,
         )
 
-    @deprecated(
-        "Deprecated class and method. Use Index and query_index() instead"
-    )
+    @deprecated("Deprecated class and method. Use Index and query_index() instead")
     def get_text_from_index(
         self, embedding_type: str, vector_db: str, doc_id: str
     ) -> Optional[str]:


### PR DESCRIPTION
## What

Fix top_k for retrieval to support  Milvus

## Why

Milvus currently allows top_k to a max of 1024. Earlier, top_k was defaulted to 10000.

## How

Change the top_k value to  5 to be practical.

## Relevant Docs

-

## Related Issues or PRs

https://github.com/Zipstack/unstract-adapters/pull/55

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

![image](https://github.com/Zipstack/unstract-sdk/assets/142381512/b48e0524-f4b5-4955-948d-59c2f57e8610)


## Checklist

I have read and understood the [Contribution Guidelines]().
