### PR TITLE
Support llm token counting using llama index response

### DIFF
--- a/src/unstract/sdk/audit.py
+++ b/src/unstract/sdk/audit.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Union
 
 import requests
 from llama_index.core.callbacks import CBEventType, TokenCountingHandler
@@ -6,6 +6,7 @@ from llama_index.core.callbacks import CBEventType, TokenCountingHandler
 from unstract.sdk.constants import LogLevel, ToolEnv
 from unstract.sdk.helper import SdkHelper
 from unstract.sdk.tool.stream import StreamMixin
+from unstract.sdk.utils.token_counter import TokenCounter
 
 
 class Audit(StreamMixin):
@@ -25,7 +26,7 @@ class Audit(StreamMixin):
     def push_usage_data(
         self,
         platform_api_key: str,
-        token_counter: TokenCountingHandler = None,
+        token_counter: Union[TokenCountingHandler, TokenCounter] = None,
         model_name: str = "",
         event_type: CBEventType = None,
         kwargs: dict[Any, Any] = None,
@@ -105,4 +106,5 @@ class Audit(StreamMixin):
             )
 
         finally:
-            token_counter.reset_counts()
+            if isinstance(token_counter, TokenCountingHandler):
+                token_counter.reset_counts()

--- a/src/unstract/sdk/utils/callback_manager.py
+++ b/src/unstract/sdk/utils/callback_manager.py
@@ -6,7 +6,6 @@ from llama_index.core.callbacks import CallbackManager as LlamaIndexCallbackMana
 from llama_index.core.callbacks import TokenCountingHandler
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.llms import LLM
-from transformers import AutoTokenizer
 from typing_extensions import deprecated
 
 from unstract.sdk.utils.usage_handler import UsageHandler
@@ -77,24 +76,35 @@ class CallbackManager:
         platform_api_key: str,
         kwargs,
     ) -> LlamaIndexCallbackManager:
-        tokenizer = CallbackManager.get_tokenizer(model)
-        token_counter = TokenCountingHandler(tokenizer=tokenizer, verbose=True)
         llm = None
         embedding = None
+        handler_list = []
         if isinstance(model, LLM):
             llm = model
+            usage_handler = UsageHandler(
+                platform_api_key=platform_api_key,
+                llm_model=llm,
+                embed_model=embedding,
+                kwargs=kwargs,
+            )
+            handler_list.append(usage_handler)
         elif isinstance(model, BaseEmbedding):
             embedding = model
-        usage_handler = UsageHandler(
-            token_counter=token_counter,
-            platform_api_key=platform_api_key,
-            llm_model=llm,
-            embed_model=embedding,
-            kwargs=kwargs,
-        )
+            # Get a tokenizer
+            tokenizer = CallbackManager.get_tokenizer(model)
+            token_counter = TokenCountingHandler(tokenizer=tokenizer, verbose=True)
+            usage_handler = UsageHandler(
+                token_counter=token_counter,
+                platform_api_key=platform_api_key,
+                llm_model=llm,
+                embed_model=embedding,
+                kwargs=kwargs,
+            )
+            handler_list.append(token_counter)
+            handler_list.append(usage_handler)
 
         callback_manager: LlamaIndexCallbackManager = LlamaIndexCallbackManager(
-            handlers=[token_counter, usage_handler]
+            handlers=handler_list
         )
         return callback_manager
 
@@ -124,11 +134,11 @@ class CallbackManager:
             elif isinstance(model, BaseEmbedding):
                 model_name = model.model_name
 
-            tokenizer: Callable[[str], list] = AutoTokenizer.from_pretrained(
+            tokenizer: Callable[[str], list] = tiktoken.encoding_for_model(
                 model_name
             ).encode
             return tokenizer
-        except OSError as e:
+        except ValueError as e:
             logger.warning(str(e))
             return fallback_tokenizer
 
@@ -145,8 +155,6 @@ class CallbackManager:
             CallbackManager.set_callback(platform_api_key, model=llm, **kwargs)
             callback_manager = llm.callback_manager
         if embedding:
-            CallbackManager.set_callback_manager(
-                platform_api_key, model=embedding, **kwargs
-            )
+            CallbackManager.set_callback(platform_api_key, model=embedding, **kwargs)
             callback_manager = embedding.callback_manager
         return callback_manager

--- a/src/unstract/sdk/utils/token_counter.py
+++ b/src/unstract/sdk/utils/token_counter.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+from llama_index.core.callbacks.schema import EventPayload
+from llama_index.core.utilities.token_counting import TokenCounter
+
+
+class Constants:
+    KEY_USAGE = "usage"
+    KEY_USAGE_METADATA = "usage_metadata"
+    KEY_EVAL_COUNT = "eval_count"
+    KEY_PROMPT_EVAL_COUNT = "prompt_eval_count"
+    KEY_RAW_RESPONSE = "_raw_response"
+    INPUT_TOKENS = "input_tokens"
+    OUTPUT_TOKENS = "output_tokens"
+    PROMPT_TOKENS = "prompt_tokens"
+    COMPLETION_TOKENS = "completion_tokens"
+    DEFAULT_TOKEN_COUNT = 0
+
+
+class TokenCounter:
+    prompt_llm_token_count: int
+    completion_llm_token_count: int
+    total_llm_token_count: int = 0
+    total_embedding_token_count: int = 0
+
+    def __init__(self, input_tokens, output_tokens):
+        self.prompt_llm_token_count = input_tokens
+        self.completion_llm_token_count = output_tokens
+        self.total_llm_token_count = (
+            self.prompt_llm_token_count + self.completion_llm_token_count
+        )
+
+    @staticmethod
+    def get_llm_token_counts(payload: dict[str, Any]) -> TokenCounter:
+        token_counter = TokenCounter(
+            input_tokens=Constants.DEFAULT_TOKEN_COUNT,
+            output_tokens=Constants.DEFAULT_TOKEN_COUNT,
+        )
+        if EventPayload.PROMPT in payload:
+            completion_raw = payload.get(EventPayload.COMPLETION).raw
+            if completion_raw:
+                if completion_raw.get(Constants.KEY_USAGE):
+                    token_counts: dict[
+                        str, int
+                    ] = TokenCounter._get_prompt_completion_tokens(completion_raw)
+                    token_counter = TokenCounter(
+                        input_tokens=token_counts[Constants.PROMPT_TOKENS],
+                        output_tokens=token_counts[Constants.COMPLETION_TOKENS],
+                    )
+                elif completion_raw.get(Constants.KEY_RAW_RESPONSE):
+                    if hasattr(
+                        completion_raw.get(Constants.KEY_RAW_RESPONSE),
+                        Constants.KEY_USAGE_METADATA,
+                    ):
+                        usage = completion_raw.get(
+                            Constants.KEY_RAW_RESPONSE
+                        ).usage_metadata
+                        token_counter = TokenCounter(
+                            input_tokens=usage.prompt_token_count,
+                            output_tokens=usage.candidates_token_count,
+                        )
+                else:
+                    prompt_tokens = Constants.DEFAULT_TOKEN_COUNT
+                    completion_tokens = Constants.DEFAULT_TOKEN_COUNT
+                    if completion_raw.get(Constants.KEY_PROMPT_EVAL_COUNT):
+                        prompt_tokens = completion_raw.get(
+                            Constants.KEY_PROMPT_EVAL_COUNT
+                        )
+                    if completion_raw.get(Constants.KEY_EVAL_COUNT):
+                        completion_tokens = completion_raw.get(Constants.KEY_EVAL_COUNT)
+                    token_counter = TokenCounter(
+                        input_tokens=prompt_tokens,
+                        output_tokens=completion_tokens,
+                    )
+        elif EventPayload.MESSAGES in payload:
+            response_raw = payload.get(EventPayload.RESPONSE).raw
+            if response_raw:
+                token_counts: dict[
+                    str, int
+                ] = TokenCounter._get_prompt_completion_tokens(response_raw)
+                token_counter = TokenCounter(
+                    input_tokens=token_counts[Constants.PROMPT_TOKENS],
+                    output_tokens=token_counts[Constants.COMPLETION_TOKENS],
+                )
+
+        return token_counter
+
+    @staticmethod
+    def _get_prompt_completion_tokens(response) -> dict[str, int]:
+        prompt_tokens = Constants.DEFAULT_TOKEN_COUNT
+        completion_tokens = Constants.DEFAULT_TOKEN_COUNT
+
+        usage = response.get(Constants.KEY_USAGE)
+        if usage:
+            if hasattr(usage, Constants.INPUT_TOKENS):
+                prompt_tokens = usage.input_tokens
+            elif hasattr(usage, Constants.PROMPT_TOKENS):
+                prompt_tokens = usage.prompt_tokens
+
+            if hasattr(usage, Constants.OUTPUT_TOKENS):
+                completion_tokens = usage.output_tokens
+            elif hasattr(usage, Constants.COMPLETION_TOKENS):
+                completion_tokens = usage.completion_tokens
+
+        token_counts: dict[str, int] = dict()
+        token_counts[Constants.PROMPT_TOKENS] = prompt_tokens
+        token_counts[Constants.COMPLETION_TOKENS] = completion_tokens
+        return token_counts


### PR DESCRIPTION
## What

Change the way token calculation is done

## Why

The existing algorithm to pass in a tokenizer to llama-index always default to passing tokenizer for gpt-3.5. This cause wrong token calculation. Hence changes are made to make use fo the token counts that come piggy-backed with the llm generation response via llama-index.


## How

Add support for various fields via which token count is received through LLM generation via llama-index

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Prompt runs were done for all LLMs (except open-ai) and token usage was checked.

Observations:
- For Mistral and Anthropic, I see that we are getting 2 event_complete callbacks. One for PROMPT-COMPLETION and another for MESSAGES_RESPONSE combinations. Both carry the same token count.
-  For ollama, re-running the same prompt back-to-back is only carrying completion tokens for the second run. First run carries both prompt and completion tokens.

## Screenshots

![image](https://github.com/Zipstack/unstract-sdk/assets/142381512/7504d86f-ea79-4d97-a497-7b2a693bd65f)


## Checklist

I have read and understood the [Contribution Guidelines]().
