### PR TITLE
Added support to pass params for prompt service API calls

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.35.0"
+__version__ = "0.36.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/prompt.py
+++ b/src/unstract/sdk/prompt.py
@@ -33,17 +33,25 @@ class PromptTool:
     def answer_prompt(
         self, payload: dict[str, Any], params: Optional[dict[str, str]] = None
     ) -> dict[str, Any]:
-        return self._post_call("answer-prompt", payload, params)
+        return self._post_call(
+            url_path="answer-prompt",
+            payload=payload,
+            params=params,
+        )
 
     def single_pass_extraction(
         self, payload: dict[str, Any], params: Optional[dict[str, str]] = None
     ) -> dict[str, Any]:
-        return self._post_call("single-pass-extraction", payload, params)
+        return self._post_call(
+            url_path="single-pass-extraction",
+            payload=payload,
+            params=params,
+        )
 
     def summarize(
         self, payload: dict[str, Any], params: Optional[dict[str, str]] = None
     ) -> dict[str, Any]:
-        return self._post_call("summarize", payload, params)
+        return self._post_call(url_path="summarize", payload=payload, params=params)
 
     def _post_call(
         self,

--- a/src/unstract/sdk/prompt.py
+++ b/src/unstract/sdk/prompt.py
@@ -25,32 +25,44 @@ class PromptTool:
             tool (AbstractTool): Instance of AbstractTool
             prompt_host (str): Host of platform service
             prompt_host (str): Port of platform service
-
         """
         self.tool = tool
         self.base_url = SdkHelper.get_platform_base_url(prompt_host, prompt_port)
         self.bearer_token = tool.get_env_or_die(ToolEnv.PLATFORM_API_KEY)
 
-    def answer_prompt(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return self._post_call("answer-prompt", payload)
+    def answer_prompt(
+        self, payload: dict[str, Any], params: Optional[dict[str, str]] = None
+    ) -> dict[str, Any]:
+        return self._post_call("answer-prompt", payload, params)
 
-    def single_pass_extraction(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return self._post_call("single-pass-extraction", payload)
+    def single_pass_extraction(
+        self, payload: dict[str, Any], params: Optional[dict[str, str]] = None
+    ) -> dict[str, Any]:
+        return self._post_call("single-pass-extraction", payload, params)
 
-    def summarize(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return self._post_call("summarize", payload)
+    def summarize(
+        self, payload: dict[str, Any], params: Optional[dict[str, str]] = None
+    ) -> dict[str, Any]:
+        return self._post_call("summarize", payload, params)
 
-    def _post_call(self, url_path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    def _post_call(
+        self,
+        url_path: str,
+        payload: dict[str, Any],
+        params: Optional[dict[str, str]] = None,
+    ) -> dict[str, Any]:
         """Invokes and communicates to prompt service to fetch response for the
         prompt.
 
         Args:
-            file_name (str): File in which the prompt is processed
-            outputs (dict): dict of all input data for the tool
-            tool_id (str): Unique ID of the tool to be processed
+            url_path (str): URL path to the service endpoint
+            payload (dict): Payload to send in the request body
+            params (dict, optional): Query parameters to include in the request
 
         Returns:
-            Sample return dict:
+            dict: Response from the prompt service
+
+            Sample Response:
             {
                 "status": "OK",
                 "error": "",
@@ -68,7 +80,12 @@ class PromptTool:
         headers: dict[str, str] = {"Authorization": f"Bearer {self.bearer_token}"}
         response: Response = Response()
         try:
-            response = requests.post(url, json=payload, headers=headers)
+            response = requests.post(
+                url=url,
+                json=payload,
+                headers=headers,
+                params=params,
+            )
             response.raise_for_status()
             result["status"] = "OK"
             result["structure_output"] = response.text


### PR DESCRIPTION
## What

- Added support to pass params for prompt service API calls
- Changed positional arguments to keyword arguments

## Why

- To include metadata along with response based on the param passed.
- To improve maintainability and readability 

## How

...

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/441

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
