### PR TITLE
Logging unhandled errors

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.38.0"
+__version__ = "0.38.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/tool/executor.py
+++ b/src/unstract/sdk/tool/executor.py
@@ -45,9 +45,7 @@ class ToolExecutor:
             args (argparse.Namespace): Parsed arguments to execute with
         """
         if args.settings is None:
-            self.tool.stream_error_and_exit(
-                "--settings are required for RUN command"
-            )
+            self.tool.stream_error_and_exit("--settings are required for RUN command")
         settings: dict[str, Any] = loads(args.settings)
 
         self._setup_for_run()
@@ -62,9 +60,13 @@ class ToolExecutor:
             f"SDK Version: {get_sdk_version()}, "
             f"adapter Version: {get_adapter_version()}"
         )
-        self.tool.run(
-            settings=settings,
-            input_file=self.tool.get_input_file(),
-            output_dir=self.tool.get_output_dir(),
-        )
+        try:
+            self.tool.run(
+                settings=settings,
+                input_file=self.tool.get_input_file(),
+                output_dir=self.tool.get_output_dir(),
+            )
+        except Exception as e:
+            self.tool.stream_error_and_exit(f"Error while running tool: {str(e)}")
+
         # TODO: Call tool method to validate if output was written

--- a/src/unstract/sdk/tool/executor.py
+++ b/src/unstract/sdk/tool/executor.py
@@ -70,9 +70,7 @@ class ToolExecutor:
                 output_dir=self.tool.get_output_dir(),
             )
         except Exception as e:
-            logger.error(
-                f"Failed to run docker container: {e}", stack_info=True, exc_info=True
-            )
+            logger.error(f"Error while tool run: {e}", stack_info=True, exc_info=True)
             self.tool.stream_error_and_exit(f"Error while running tool: {str(e)}")
 
         # TODO: Call tool method to validate if output was written

--- a/src/unstract/sdk/tool/executor.py
+++ b/src/unstract/sdk/tool/executor.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import shutil
 from json import loads
 from pathlib import Path
@@ -10,6 +11,8 @@ from unstract.sdk import get_sdk_version
 from unstract.sdk.constants import Command
 from unstract.sdk.tool.base import BaseTool
 from unstract.sdk.tool.validator import ToolValidator
+
+logger = logging.getLogger(__name__)
 
 
 class ToolExecutor:
@@ -67,6 +70,9 @@ class ToolExecutor:
                 output_dir=self.tool.get_output_dir(),
             )
         except Exception as e:
+            logger.error(
+                f"Failed to run docker container: {e}", stack_info=True, exc_info=True
+            )
             self.tool.stream_error_and_exit(f"Error while running tool: {str(e)}")
 
         # TODO: Call tool method to validate if output was written


### PR DESCRIPTION
## What

Stream unhandled error to logs on tool run.

## Why

Actual error msgs where not getting streamed

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Created text adapter with wrong credentials.  So this will go into the unhandled exception block of the tool run. Verified the stream logs(PFA screenshot).

## Screenshots

![image](https://github.com/user-attachments/assets/a927b44f-032c-421c-a2d8-1a73f57860ec)

![image](https://github.com/user-attachments/assets/188a4be0-bf2b-49b5-8859-08b86f66a3cd)

## Checklist

I have read and understood the [Contribution Guidelines]().
