### PR TITLE
Feat/usage reporting page

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,8 +5,7 @@
 groups = ["default", "docs", "lint", "test"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:78f89c18fa5f446783efe32514a77ab4a8e9c778128fd89330da9972d62f2b0d"
-
+content_hash = "sha256:4d41c155852fe8a3377ada09498839c9c20105dfb4adfd43ae12aa0d934a5eba"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -2457,7 +2456,7 @@ files = [
 
 [[package]]
 name = "pdfplumber"
-version = "0.11.2"
+version = "0.11.3"
 requires_python = ">=3.8"
 summary = "Plumb a PDF for detailed information about each char, rectangle, and line."
 groups = ["default"]
@@ -2467,8 +2466,8 @@ dependencies = [
     "pypdfium2>=4.18.0",
 ]
 files = [
-    {file = "pdfplumber-0.11.2-py3-none-any.whl", hash = "sha256:024a7e0f8f4e7bbec8e1f6f694faeaa7b9fe33a0c1f9edd9d3f77298d9146b87"},
-    {file = "pdfplumber-0.11.2.tar.gz", hash = "sha256:f237ce88e9918358f3848f4bae469358ca121ca412098e370908878ec9da699a"},
+    {file = "pdfplumber-0.11.3-py3-none-any.whl", hash = "sha256:4f3e13795d18b2e53dfc4cd667a3bc2478cd6975fc9a188881376265d599c5a6"},
+    {file = "pdfplumber-0.11.3.tar.gz", hash = "sha256:43a3cac33d2135ce00ac59ad5bc3813a33afe0f513d9284c0e8cb6e447ed6e53"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "lint", "test"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:cf364e6a4d2acace552281bc7e34640d6f5cb0070350efd29175ce4b12a6a182"
+content_hash = "sha256:06b886ad4b534fca53e498c7a8e9ba71b652a15c43791fd1007ae1537e92b7e8"
 
 [[package]]
 name = "aiohttp"
@@ -2290,6 +2290,37 @@ files = [
 ]
 
 [[package]]
+name = "pdfminer-six"
+version = "20231228"
+requires_python = ">=3.6"
+summary = "PDF parser and analyzer"
+groups = ["default"]
+dependencies = [
+    "charset-normalizer>=2.0.0",
+    "cryptography>=36.0.0",
+]
+files = [
+    {file = "pdfminer.six-20231228-py3-none-any.whl", hash = "sha256:e8d3c3310e6fbc1fe414090123ab01351634b4ecb021232206c4c9a8ca3e3b8f"},
+    {file = "pdfminer.six-20231228.tar.gz", hash = "sha256:6004da3ad1a7a4d45930cb950393df89b068e73be365a6ff64a838d37bcb08c4"},
+]
+
+[[package]]
+name = "pdfplumber"
+version = "0.11.2"
+requires_python = ">=3.8"
+summary = "Plumb a PDF for detailed information about each char, rectangle, and line."
+groups = ["default"]
+dependencies = [
+    "Pillow>=9.1",
+    "pdfminer-six==20231228",
+    "pypdfium2>=4.18.0",
+]
+files = [
+    {file = "pdfplumber-0.11.2-py3-none-any.whl", hash = "sha256:024a7e0f8f4e7bbec8e1f6f694faeaa7b9fe33a0c1f9edd9d3f77298d9146b87"},
+    {file = "pdfplumber-0.11.2.tar.gz", hash = "sha256:f237ce88e9918358f3848f4bae469358ca121ca412098e370908878ec9da699a"},
+]
+
+[[package]]
 name = "pgvector"
 version = "0.2.5"
 requires_python = ">=3.8"
@@ -2741,6 +2772,28 @@ dependencies = [
 files = [
     {file = "pypdf-4.3.1-py3-none-any.whl", hash = "sha256:64b31da97eda0771ef22edb1bfecd5deee4b72c3d1736b7df2689805076d6418"},
     {file = "pypdf-4.3.1.tar.gz", hash = "sha256:b2f37fe9a3030aa97ca86067a56ba3f9d3565f9a791b305c7355d8392c30d91b"},
+]
+
+[[package]]
+name = "pypdfium2"
+version = "4.30.0"
+requires_python = ">=3.6"
+summary = "Python bindings to PDFium"
+groups = ["default"]
+files = [
+    {file = "pypdfium2-4.30.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:b33ceded0b6ff5b2b93bc1fe0ad4b71aa6b7e7bd5875f1ca0cdfb6ba6ac01aab"},
+    {file = "pypdfium2-4.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4e55689f4b06e2d2406203e771f78789bd4f190731b5d57383d05cf611d829de"},
+    {file = "pypdfium2-4.30.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e6e50f5ce7f65a40a33d7c9edc39f23140c57e37144c2d6d9e9262a2a854854"},
+    {file = "pypdfium2-4.30.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3d0dd3ecaffd0b6dbda3da663220e705cb563918249bda26058c6036752ba3a2"},
+    {file = "pypdfium2-4.30.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc3bf29b0db8c76cdfaac1ec1cde8edf211a7de7390fbf8934ad2aa9b4d6dfad"},
+    {file = "pypdfium2-4.30.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1f78d2189e0ddf9ac2b7a9b9bd4f0c66f54d1389ff6c17e9fd9dc034d06eb3f"},
+    {file = "pypdfium2-4.30.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5eda3641a2da7a7a0b2f4dbd71d706401a656fea521b6b6faa0675b15d31a163"},
+    {file = "pypdfium2-4.30.0-py3-none-musllinux_1_1_i686.whl", hash = "sha256:0dfa61421b5eb68e1188b0b2231e7ba35735aef2d867d86e48ee6cab6975195e"},
+    {file = "pypdfium2-4.30.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:f33bd79e7a09d5f7acca3b0b69ff6c8a488869a7fab48fdf400fec6e20b9c8be"},
+    {file = "pypdfium2-4.30.0-py3-none-win32.whl", hash = "sha256:ee2410f15d576d976c2ab2558c93d392a25fb9f6635e8dd0a8a3a5241b275e0e"},
+    {file = "pypdfium2-4.30.0-py3-none-win_amd64.whl", hash = "sha256:90dbb2ac07be53219f56be09961eb95cf2473f834d01a42d901d13ccfad64b4c"},
+    {file = "pypdfium2-4.30.0-py3-none-win_arm64.whl", hash = "sha256:119b2969a6d6b1e8d55e99caaf05290294f2d0fe49c12a3f17102d01c441bd29"},
+    {file = "pypdfium2-4.30.0.tar.gz", hash = "sha256:48b5b7e5566665bc1015b9d69c1ebabe21f6aee468b509531c3c8318eeee2e16"},
 ]
 
 [[package]]
@@ -3265,8 +3318,8 @@ requires_python = ">=3.7"
 summary = "Database Abstraction Library"
 groups = ["default"]
 dependencies = [
+    "SQLAlchemy==2.0.31",
     "greenlet!=0.4.17",
-    "sqlalchemy==2.0.31",
 ]
 files = [
     {file = "SQLAlchemy-2.0.31-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f2a213c1b699d3f5768a7272de720387ae0122f1becf0901ed6eaa1abd1baf6c"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "lint", "test"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:147e1b2304da936e35ec6f07ad09ac257699abcf8bdc56281dcabf72c0e891eb"
+content_hash = "sha256:c4cb2641c971f94a4213d58b7c6f9f90dfc3555b44ea59ae89bdb35f7cd4c365"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -17,7 +17,6 @@ files = [
     {file = "aiohappyeyeballs-2.3.4-py3-none-any.whl", hash = "sha256:40a16ceffcf1fc9e142fd488123b2e218abc4188cf12ac20c67200e1579baa42"},
     {file = "aiohappyeyeballs-2.3.4.tar.gz", hash = "sha256:7e1ae8399c320a8adec76f6c919ed5ceae6edd4c3672f4d9eae2b27e37c80ff6"},
 ]
-
 
 [[package]]
 name = "aiohttp"
@@ -3408,8 +3407,8 @@ requires_python = ">=3.7"
 summary = "Database Abstraction Library"
 groups = ["default"]
 dependencies = [
-    "SQLAlchemy==2.0.31",
     "greenlet!=0.4.17",
+    "sqlalchemy==2.0.31",
 ]
 files = [
     {file = "SQLAlchemy-2.0.31-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f2a213c1b699d3f5768a7272de720387ae0122f1becf0901ed6eaa1abd1baf6c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     # For Llama Parse X2Text
     "llama-parse==0.4.1",
     "httpx>=0.25.2",
+    "pdfplumber>=0.11.2",
 ]
 readme = "README.md"
 urls = { Homepage = "https://unstract.com", "Release notes" = "https://github.com/Zipstack/unstract-sdk/releases", Source = "https://github.com/Zipstack/unstract-sdk" }

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.42.0"
+__version__ = "0.41.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.42.1"
+__version__ = "0.44.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.41.0"
+__version__ = "0.42.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.43.0"
+__version__ = "0.42.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/audit.py
+++ b/src/unstract/sdk/audit.py
@@ -118,7 +118,6 @@ class Audit(StreamMixin):
         self,
         platform_api_key: str,
         page_count: int,
-        file_name: str,
         file_size: int,
         file_type: str,
         kwargs: dict[Any, Any] = None,
@@ -126,6 +125,7 @@ class Audit(StreamMixin):
         platform_host = self.get_env_or_die(ToolEnv.PLATFORM_HOST)
         platform_port = self.get_env_or_die(ToolEnv.PLATFORM_PORT)
         run_id = kwargs.get("run_id", "")
+        file_name = kwargs.get("file_name", "")
         base_url = SdkHelper.get_platform_base_url(
             platform_host=platform_host, platform_port=platform_port
         )

--- a/src/unstract/sdk/audit.py
+++ b/src/unstract/sdk/audit.py
@@ -125,7 +125,7 @@ class Audit(StreamMixin):
     ) -> None:
         platform_host = self.get_env_or_die(ToolEnv.PLATFORM_HOST)
         platform_port = self.get_env_or_die(ToolEnv.PLATFORM_PORT)
-
+        run_id = kwargs.get("run_id", "")
         base_url = SdkHelper.get_platform_base_url(
             platform_host=platform_host, platform_port=platform_port
         )
@@ -138,6 +138,7 @@ class Audit(StreamMixin):
             "file_name": file_name,
             "file_size": file_size,
             "file_type": file_type,
+            "run_id": run_id,
         }
 
         try:

--- a/src/unstract/sdk/audit.py
+++ b/src/unstract/sdk/audit.py
@@ -119,6 +119,8 @@ class Audit(StreamMixin):
         platform_api_key: str,
         page_count: int,
         file_name: str,
+        file_size: int,
+        file_type: str,
         kwargs: dict[Any, Any] = None,
     ) -> None:
         platform_host = self.get_env_or_die(ToolEnv.PLATFORM_HOST)
@@ -131,8 +133,15 @@ class Audit(StreamMixin):
         url = f"{base_url}/page-usage"
         headers = {"Authorization": f"Bearer {bearer_token}"}
 
+        data = {
+            "page_count": page_count,
+            "file_name": file_name,
+            "file_size": file_size,
+            "file_type": file_type,
+        }
+
         try:
-            response = requests.post(url, headers=headers, json={}, timeout=30)
+            response = requests.post(url, headers=headers, json=data, timeout=30)
             if response.status_code != 200:
                 self.stream_log(
                     log=(

--- a/src/unstract/sdk/constants.py
+++ b/src/unstract/sdk/constants.py
@@ -158,3 +158,8 @@ class PublicAdapterKeys:
     PUBLIC_EMBEDDING_CONFIG = "PUBLIC_EMBEDDING_CONFIG"
     PUBLIC_VECTOR_DB_CONFIG = "PUBLIC_VECTOR_DB_CONFIG"
     PUBLIC_X2TEXT_CONFIG = "PUBLIC_X2TEXT_CONFIG"
+
+
+class MimeType:
+    PDF = "application/pdf"
+    TEXT = "text/plain"

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -242,35 +242,28 @@ class Index:
             full_text = []
             extracted_text = ""
             try:
-                mime_type = ToolUtils.get_file_mime_type(file_path)
-                if mime_type == "text/plain":
-                    with open(file_path, encoding="utf-8") as file:
-                        extracted_text = file.read()
-                else:
-                    x2text = X2Text(
-                        tool=self.tool, adapter_instance_id=x2text_instance_id
+                x2text = X2Text(tool=self.tool, adapter_instance_id=x2text_instance_id)
+                if enable_highlight and isinstance(
+                    x2text._x2text_instance, LLMWhisperer
+                ):
+                    process_response: TextExtractionResult = x2text.process(
+                        input_file_path=file_path,
+                        output_file_path=output_file_path,
+                        enable_highlight=enable_highlight,
                     )
-                    if enable_highlight and isinstance(
-                        x2text._x2text_instance, LLMWhisperer
-                    ):
-                        process_response: TextExtractionResult = x2text.process(
-                            input_file_path=file_path,
-                            output_file_path=output_file_path,
-                            enable_highlight=enable_highlight,
-                        )
-                        whisper_hash_value = (
-                            process_response.extraction_metadata.whisper_hash
-                        )
+                    whisper_hash_value = (
+                        process_response.extraction_metadata.whisper_hash
+                    )
 
-                        metadata = {X2TextConstants.WHISPER_HASH: whisper_hash_value}
+                    metadata = {X2TextConstants.WHISPER_HASH: whisper_hash_value}
 
-                        self.tool.update_exec_metadata(metadata)
+                    self.tool.update_exec_metadata(metadata)
 
-                    else:
-                        process_response: TextExtractionResult = x2text.process(
-                            input_file_path=file_path,
-                            output_file_path=output_file_path,
-                        )
+                else:
+                    process_response: TextExtractionResult = x2text.process(
+                        input_file_path=file_path,
+                        output_file_path=output_file_path,
+                    )
 
                     extracted_text = process_response.extracted_text
             except AdapterError as e:

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -242,7 +242,11 @@ class Index:
             full_text = []
             extracted_text = ""
             try:
-                x2text = X2Text(tool=self.tool, adapter_instance_id=x2text_instance_id)
+                x2text = X2Text(
+                    tool=self.tool,
+                    adapter_instance_id=x2text_instance_id,
+                    usage_kwargs=usage_kwargs,
+                )
                 if enable_highlight and isinstance(
                     x2text._x2text_instance, LLMWhisperer
                 ):

--- a/src/unstract/sdk/utils/tool_utils.py
+++ b/src/unstract/sdk/utils/tool_utils.py
@@ -155,6 +155,8 @@ class ToolUtils:
         Returns:
             int: Total count of individual pages extracted from the input string
         """
+        if not pages_string:
+            return max_page
         pages_list: list[int] = []
         parts = pages_string.split(",")
         for part in parts:

--- a/src/unstract/sdk/utils/tool_utils.py
+++ b/src/unstract/sdk/utils/tool_utils.py
@@ -100,3 +100,20 @@ class ToolUtils:
             input_file_mime = magic.from_buffer(sample_contents, mime=True)
             input_file_obj.seek(0)
         return input_file_mime
+
+    @staticmethod
+    def get_file_size(input_file: Path) -> int:
+        """Gets the file size in bytes for an input file.
+        Args:
+            input_file (Path): Path object of the input file
+
+        Returns:
+            str: MIME type of the file
+        """
+        with open(input_file, mode="rb") as input_file_obj:
+            input_file_obj.seek(0, 2)  # Move the cursor to the end of the file
+            file_length = (
+                input_file_obj.tell()
+            )  # Get the current position of the cursor, which is the file length
+            input_file_obj.seek(0)
+        return file_length

--- a/src/unstract/sdk/utils/tool_utils.py
+++ b/src/unstract/sdk/utils/tool_utils.py
@@ -132,3 +132,54 @@ class ToolUtils:
         """
         return string.lower() == "true"
 
+    # Used the same function from LLM Whisperer
+    @staticmethod
+    def calculate_page_count(
+        pages_string: str, max_page: int = 0, min_page: int = 1
+    ) -> int:
+        """Calculates the total number of pages based on the input string of
+        page numbers or ranges.
+
+        Parses the input 'pages_string' to extract individual page numbers or
+        ranges separated by commas.
+        Supports ranges like '1-5' or open-ended ranges like '4-'.
+        The 'max_page' parameter defines the upper limit for page numbers.
+        The 'min_page' parameter defines the lower limit for page numbers.
+
+        Args:
+            pages_string (str): String containing page numbers or ranges
+            separated by commas
+            max_page (int): Upper limit for page numbers (default is 0)
+            min_page (int): Lower limit for page numbers (default is 1)
+
+        Returns:
+            int: Total count of individual pages extracted from the input string
+        """
+        pages_list: list[int] = []
+        parts = pages_string.split(",")
+        for part in parts:
+            part = part.strip()
+            if "-" in part:
+                if part.startswith("-"):  # e.g., "-5"
+                    end = int(part[1:])
+                    end = min(end, max_page)
+                    pages_list.extend(range(min_page, end + 1))
+                elif part.endswith("-"):  # e.g., "4-"
+                    start = int(part[:-1])
+                    if start < 0:
+                        start = 0
+                    if max_page is None:
+                        raise ValueError(
+                            "max_page must be defined for open-ended ranges like '4-'"
+                        )
+                    pages_list.extend(range(start, max_page + 1))
+                else:  # e.g., "1-5"
+                    start, end = map(int, part.split("-"))
+                    if start < 0:
+                        start = 0
+                    if end > max_page:
+                        end = max_page
+                    pages_list.extend(range(start, end + 1))
+            else:
+                pages_list.append(int(part))
+        return len(pages_list)

--- a/src/unstract/sdk/x2txt.py
+++ b/src/unstract/sdk/x2txt.py
@@ -9,18 +9,16 @@ from unstract.sdk.adapters.x2text import adapters
 from unstract.sdk.adapters.x2text.constants import X2TextConstants
 from unstract.sdk.adapters.x2text.dto import TextExtractionResult
 from unstract.sdk.adapters.x2text.x2text_adapter import X2TextAdapter
-from unstract.sdk.constants import LogLevel
+from unstract.sdk.audit import Audit
+from unstract.sdk.constants import LogLevel, ToolEnv
 from unstract.sdk.exceptions import X2TextError
 from unstract.sdk.helper import SdkHelper
 from unstract.sdk.tool.base import BaseTool
+from unstract.sdk.utils import ToolUtils
 
 
 class X2Text(metaclass=ABCMeta):
-    def __init__(
-        self,
-        tool: BaseTool,
-        adapter_instance_id: Optional[str] = None
-    ):
+    def __init__(self, tool: BaseTool, adapter_instance_id: Optional[str] = None):
         self._tool = tool
         self._x2text_adapters = adapters
         self._adapter_instance_id = adapter_instance_id
@@ -82,6 +80,13 @@ class X2Text(metaclass=ABCMeta):
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
     ) -> TextExtractionResult:
+        mime_type = ToolUtils.get_file_mime_type(input_file_path)
+        print(mime_type)
+        Audit().push_page_usage_data(
+            platform_api_key=self._tool.get_env_or_die(ToolEnv.PLATFORM_API_KEY),
+            file_name="test",
+            page_count=2,
+        )
         return self._x2text_instance.process(
             input_file_path, output_file_path, **kwargs
         )

--- a/src/unstract/sdk/x2txt.py
+++ b/src/unstract/sdk/x2txt.py
@@ -1,4 +1,3 @@
-import os
 from abc import ABCMeta
 from typing import Any, Optional
 
@@ -113,8 +112,6 @@ class X2Text(metaclass=ABCMeta):
         return self._x2text_instance
 
     def push_usage_details(self, input_file_path: str, mime_type: str) -> None:
-        file_name = os.path.basename(input_file_path)
-
         file_size = ToolUtils.get_file_size(input_file_path)
 
         self._x2text_instance
@@ -131,7 +128,6 @@ class X2Text(metaclass=ABCMeta):
                 )
             Audit().push_page_usage_data(
                 platform_api_key=self._tool.get_env_or_die(ToolEnv.PLATFORM_API_KEY),
-                file_name=file_name,
                 file_size=file_size,
                 file_type=mime_type,
                 page_count=page_count,
@@ -142,7 +138,6 @@ class X2Text(metaclass=ABCMeta):
             # as single page documents as there in no concept of page numbers.
             Audit().push_page_usage_data(
                 platform_api_key=self._tool.get_env_or_die(ToolEnv.PLATFORM_API_KEY),
-                file_name=file_name,
                 file_size=file_size,
                 file_type=mime_type,
                 page_count=1,

--- a/src/unstract/sdk/x2txt.py
+++ b/src/unstract/sdk/x2txt.py
@@ -90,20 +90,20 @@ class X2Text(metaclass=ABCMeta):
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
     ) -> TextExtractionResult:
-        # The will be executed each and every time text extraction takes place
         mime_type = ToolUtils.get_file_mime_type(input_file_path)
-        self.push_usage_details(input_file_path, mime_type)
-
+        text_extraction_result: TextExtractionResult = None
         if mime_type == MimeType.TEXT:
             with open(input_file_path, encoding="utf-8") as file:
                 extracted_text = file.read()
-                return TextExtractionResult(
+                text_extraction_result = TextExtractionResult(
                     extracted_text=extracted_text, extraction_metadata=None
                 )
-
-        return self._x2text_instance.process(
+        text_extraction_result = self._x2text_instance.process(
             input_file_path, output_file_path, **kwargs
         )
+        # The will be executed each and every time text extraction takes place
+        self.push_usage_details(input_file_path, mime_type)
+        return text_extraction_result
 
     @deprecated("Instantiate X2Text and call process() instead")
     def get_x2text(self, adapter_instance_id: str) -> X2TextAdapter:


### PR DESCRIPTION
## What

 Push page usage every time an extraction takes place irrespective of the text extractor used

## Why

Report pages used metric to platform

## How

Pushing the data to platform service similar to what is done for token usage reporting.

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/547

## Dependencies Versions / Env Variables

-

## Notes on Testing

Tested the SDK with backend
Tested the SDK with structure and text extractor tools

## Screenshots

![image](https://github.com/user-attachments/assets/e3a5017b-935f-40e7-98ea-ade2bf3a52d5)
![image](https://github.com/user-attachments/assets/db051d9d-3024-4782-addc-0e6202456111)


## Checklist

I have read and understood the [Contribution Guidelines]().
