### PR TITLE
Feat/dynamic page number llm whisperer

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.41.1"
+__version__ = "0.42.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer/src/constants.py
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer/src/constants.py
@@ -61,6 +61,7 @@ class WhispererConfig:
     HORIZONTAL_STRETCH_FACTOR = "horizontal_stretch_factor"
     PAGES_TO_EXTRACT = "pages_to_extract"
     STORE_METADATA_FOR_HIGHLIGHTING = "store_metadata_for_highlighting"
+    PAGE_SEPARATOR = "page_seperator"
 
 
 class WhisperStatus:
@@ -86,3 +87,4 @@ class WhispererDefaults:
     POLL_INTERVAL = int(os.getenv(WhispererEnv.POLL_INTERVAL, 30))
     MAX_POLLS = int(os.getenv(WhispererEnv.MAX_POLLS, 30))
     PAGES_TO_EXTRACT = ""
+    PAGE_SEPARATOR = "<<< >>>"

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -10,7 +10,10 @@ from requests.exceptions import ConnectionError, HTTPError, Timeout
 from unstract.sdk.adapters.exceptions import ExtractorError
 from unstract.sdk.adapters.utils import AdapterUtils
 from unstract.sdk.adapters.x2text.constants import X2TextConstants
-from unstract.sdk.adapters.x2text.dto import TextExtractionMetadata, TextExtractionResult
+from unstract.sdk.adapters.x2text.dto import (
+    TextExtractionMetadata,
+    TextExtractionResult,
+)
 from unstract.sdk.adapters.x2text.llm_whisperer.src.constants import (
     HTTPMethod,
     OutputModes,
@@ -158,6 +161,10 @@ class LLMWhisperer(X2TextAdapter):
             WhispererConfig.PAGES_TO_EXTRACT: self.config.get(
                 WhispererConfig.PAGES_TO_EXTRACT,
                 WhispererDefaults.PAGES_TO_EXTRACT,
+            ),
+            WhispererConfig.PAGE_SEPARATOR: self.config.get(
+                WhispererConfig.PAGE_SEPARATOR,
+                WhispererDefaults.PAGE_SEPARATOR,
             ),
         }
         if not params[WhispererConfig.FORCE_TEXT_PROCESSING]:

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -88,7 +88,7 @@
       "type": "string",
       "title": "Page separator",
       "default": "<<< >>>",
-      "pattern": "",
+      "pattern": "^\\S+(?:\\s+\\{\\{page_no\\}\\})?\\s+\\S+$",
       "description": "Specify how the pages to separate (e.g. << {{page_no}} >>, << >>). Leave the {{page_no}} empty if you don't want the page number as page separator."
     }
   },

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -88,7 +88,7 @@
       "type": "string",
       "title": "Page separator",
       "default": "<<< >>>",
-      "description": "Specify how the pages to separate (e.g. << {{page_no}} >>, << >>). Leave the {{page_no}} empty if you don't want the page number as page separator."
+      "description": "Specify a pattern to separate the pages in the document (e.g., <<< {{page_no}} >>>, <<< >>>). This pattern will be inserted at the end of every page. Omit {{page_no}} if you don't want to include the page number in the separator."
     }
   },
   "if": {

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -88,7 +88,7 @@
       "type": "string",
       "title": "Page separator",
       "default": "<<< >>>",
-      "pattern": "^\\S+(?:\\s+{{page_no}})?\\s+\\S+$",
+      "pattern": "",
       "description": "Specify how the pages to separate (e.g. << {{page_no}} >>, << >>). Leave the {{page_no}} empty if you don't want the page number as page separator."
     }
   },

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -88,7 +88,6 @@
       "type": "string",
       "title": "Page separator",
       "default": "<<< >>>",
-      "pattern": "^\\S+(?:\\s+\\{\\{page_no\\}\\})?\\s+\\S+$",
       "description": "Specify how the pages to separate (e.g. << {{page_no}} >>, << >>). Leave the {{page_no}} empty if you don't want the page number as page separator."
     }
   },

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -83,6 +83,13 @@
       "default": "",
       "pattern": "^(\\s*\\d+-\\d+|\\s*\\d+-|\\s*\\d+|^$)(,\\d+-\\d+|,\\d+-|,\\d+)*$",
       "description": "Specify the range of pages to extract (e.g., 1-5, 7, 10-12, 50-). Leave it empty to extract all pages."
+    },
+    "page_seperator": {
+      "type": "string",
+      "title": "Page separator",
+      "default": "<<< >>>",
+      "pattern": "^\\S+(?:\\s+{{page_no}})?\\s+\\S+$",
+      "description": "Specify how the pages to separate (e.g. << {{page_no}} >>, << >>). Leave the {{page_no}} empty if you don't want the page number as page separator."
     }
   },
   "if": {


### PR DESCRIPTION
## What

... Add `page-separator` field in llm-whisperer

## Why

... Need to have this field in llm-whisperer

## How

... Changes on llm-whisperer adapter

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

1. Editable install on `unstract/sdk` on backend
2. Tested pdf raw view with this `unstract/sdk` changes
3. pdf format is <<< 1 >>>, if page_seperator format is <<< {{page_no}} >>>
4. pdf format is <<< >>>,  if page_seperator format is empty

## Screenshots

...
![Screenshot from 2024-08-06 12-25-49](https://github.com/user-attachments/assets/d23d9c61-11cc-4a3a-882d-79de7e2a5890)
![Screenshot from 2024-08-06 12-24-22](https://github.com/user-attachments/assets/b2dfd8f7-0ae0-4cbc-aa05-4c5d5f824a44)


## Checklist

I have read and understood the [Contribution Guidelines]().
