### PR TITLE
fix: Error handling improvement for gemini

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.41.0"
+__version__ = "0.41.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapter.py
+++ b/src/unstract/sdk/adapter.py
@@ -58,6 +58,7 @@ class ToolAdapter(PlatformBase):
         if response.status_code == 200:
             adapter_data: dict[str, Any] = response.json()
 
+            # TODO: Print config after redacting sensitive information
             self.tool.stream_log(
                 "Successfully retrieved adapter config "
                 f"for adapter: {adapter_instance_id}"
@@ -104,18 +105,16 @@ class ToolAdapter(PlatformBase):
             Any: engine
         """
         # Check if the adapter ID matches any public adapter keys
-        if SdkHelper.is_public_adapter(
-            adapter_id=adapter_instance_id
-        ):
-            adapter_metadata_config = tool.get_env_or_die(
-                adapter_instance_id
-            )
+        if SdkHelper.is_public_adapter(adapter_id=adapter_instance_id):
+            adapter_metadata_config = tool.get_env_or_die(adapter_instance_id)
             adapter_metadata = json.loads(adapter_metadata_config)
             return adapter_metadata
         platform_host = tool.get_env_or_die(ToolEnv.PLATFORM_HOST)
         platform_port = tool.get_env_or_die(ToolEnv.PLATFORM_PORT)
 
-        tool.stream_log("Connecting to DB and getting table metadata")
+        tool.stream_log(
+            f"Connecting to DB and getting table metadata for {adapter_instance_id}"
+        )
         tool_adapter = ToolAdapter(
             tool=tool,
             platform_host=platform_host,

--- a/src/unstract/sdk/adapters/exceptions.py
+++ b/src/unstract/sdk/adapters/exceptions.py
@@ -1,14 +1,8 @@
-from unstract.sdk.adapters.constants import Common
+from unstract.sdk.exceptions import SdkError
 
 
-class AdapterError(Exception):
-    def __init__(self, message: str = Common.DEFAULT_ERR_MESSAGE):
-        super().__init__(message)
-        # Make it user friendly wherever possible
-        self.message = message
-
-    def __str__(self) -> str:
-        return self.message
+class AdapterError(SdkError):
+    pass
 
 
 class LLMError(AdapterError):

--- a/src/unstract/sdk/adapters/llm/exceptions.py
+++ b/src/unstract/sdk/adapters/llm/exceptions.py
@@ -1,0 +1,25 @@
+from openai import APIError as OpenAIAPIError
+from vertexai.generative_models import ResponseValidationError
+
+from unstract.sdk.adapters.exceptions import LLMError
+from unstract.sdk.adapters.llm.open_ai.src.open_ai import OpenAILLM
+from unstract.sdk.adapters.llm.vertex_ai.src.vertex_ai import VertexAILLM
+
+
+def parse_llm_err(e: Exception) -> LLMError:
+    """Parses the exception from LLM provider.
+
+    Helps parse the LLM error and wraps it with our
+    custom exception object to contain a user friendly message.
+
+    Args:
+        e (Exception): Error from LLM provider
+
+    Returns:
+        LLMError: Unstract's LLMError object
+    """
+    if isinstance(e, ResponseValidationError):
+        return VertexAILLM.parse_llm_err(e)
+    elif isinstance(e, OpenAIAPIError):
+        return OpenAILLM.parse_llm_err(e)
+    return LLMError(str(e))

--- a/src/unstract/sdk/adapters/llm/llm_adapter.py
+++ b/src/unstract/sdk/adapters/llm/llm_adapter.py
@@ -6,6 +6,7 @@ from llama_index.core.llms import LLM, MockLLM
 
 from unstract.sdk.adapters.base import Adapter
 from unstract.sdk.adapters.enums import AdapterTypes
+from unstract.sdk.adapters.exceptions import LLMError
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,20 @@ class LLMAdapter(Adapter, ABC):
     @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM
+
+    @staticmethod
+    def parse_llm_err(e: Exception) -> LLMError:
+        """Parse the error from an LLM provider.
+
+        Helps parse errors from a provider and wraps with custom exception.
+
+        Args:
+            e (Exception): Exception from LLM provider
+
+        Returns:
+            LLMError: Error to be sent to the user
+        """
+        return LLMError(str(e))
 
     def get_llm_instance(self) -> LLM:
         """Instantiate the llama index LLM class.

--- a/src/unstract/sdk/tool/executor.py
+++ b/src/unstract/sdk/tool/executor.py
@@ -49,17 +49,22 @@ class ToolExecutor:
             self.tool.stream_error_and_exit("--settings are required for RUN command")
         settings: dict[str, Any] = loads(args.settings)
 
-        self._setup_for_run()
+        self.tool.stream_log(
+            f"Running tool with "
+            f"Workflow ID: {self.tool.workflow_id}, "
+            f"Execution ID: {self.tool.execution_id}, "
+            f"SDK Version: {get_sdk_version()}"
+        )
 
+        self._setup_for_run()
         validator = ToolValidator(self.tool)
         settings = validator.validate_pre_execution(settings=settings)
 
         self.tool.stream_log(
-            f"Running tool for "
-            f"Workflow ID: {self.tool.workflow_id}, "
-            f"Execution ID: {self.tool.execution_id}, "
-            f"SDK Version: {get_sdk_version()}, "
+            f"Executing for file: {self.tool.get_exec_metadata['source_name']}, "
+            f"with tool settings: {settings}"
         )
+
         try:
             self.tool.run(
                 settings=settings,

--- a/src/unstract/sdk/tool/stream.py
+++ b/src/unstract/sdk/tool/stream.py
@@ -6,6 +6,7 @@ from typing import Any
 from deprecated import deprecated
 
 from unstract.sdk.constants import Command, LogLevel, LogStage, ToolEnv
+from unstract.sdk.utils import ToolUtils
 
 
 class StreamMixin:
@@ -26,7 +27,7 @@ class StreamMixin:
 
         """
         self.log_level = log_level
-        self._exec_by_tool = bool(
+        self._exec_by_tool = ToolUtils.str_to_bool(
             os.environ.get(ToolEnv.EXECUTION_BY_TOOL, "False")
         )
         super().__init__(**kwargs)
@@ -78,9 +79,7 @@ class StreamMixin:
         if self._exec_by_tool:
             exit(1)
         else:
-            raise RuntimeError(
-                "RuntimeError from SDK, check the above log for details"
-            )
+            raise RuntimeError("RuntimeError from SDK, check the above log for details")
 
     def get_env_or_die(self, env_key: str) -> str:
         """Returns the value of an env variable.
@@ -232,9 +231,7 @@ class StreamMixin:
         print(json.dumps(record))
 
     @staticmethod
-    @deprecated(
-        version="0.4.4", reason="Use `BaseTool.write_to_result()` instead"
-    )
+    @deprecated(version="0.4.4", reason="Use `BaseTool.write_to_result()` instead")
     def stream_result(result: dict[Any, Any], **kwargs: Any) -> None:
         """Streams the result of the tool using the Unstract protocol RESULT to
         stdout.

--- a/src/unstract/sdk/utils/tool_utils.py
+++ b/src/unstract/sdk/utils/tool_utils.py
@@ -100,3 +100,17 @@ class ToolUtils:
             input_file_mime = magic.from_buffer(sample_contents, mime=True)
             input_file_obj.seek(0)
         return input_file_mime
+
+    @staticmethod
+    def str_to_bool(string: str) -> bool:
+        """String value of boolean to boolean.
+
+        Useful while parsing envs to bool.
+
+        Args:
+            string (str): value like "true", "True" etc..
+
+        Returns:
+            bool
+        """
+        return string.lower() == "true"


### PR DESCRIPTION
## What

- Improved error handling for gemini LLM
- Minor logs added for more context during debugging
- Refactored SDK / adapter error handling for LLM
- AdapterError now subclasses SdkError
- Bumped SDK to 0.41.1

## Why

- Output token related errors were not displayed correctly for gemini

## How
- Parsed the error response from gemini and wrapped with a custom exception

## Relevant Docs

- https://ai.google.dev/api/generate-content#generatecontentresponse

## Notes on Testing

- Tested locally for various LLMs - could reproduce only with gpt3.5 and gemini



## Screenshots

![image](https://github.com/user-attachments/assets/a8e55928-20eb-48de-aef2-153b98a1b424)

![image](https://github.com/user-attachments/assets/aca4007c-083d-4585-bf20-f87826ae34ea)
## Checklist

I have read and understood the [Contribution Guidelines]().
