### PR TITLE
fix: Adapter instance retrieval error handling from platform service

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.42.0"
+__version__ = "0.42.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapter.py
+++ b/src/unstract/sdk/adapter.py
@@ -40,7 +40,7 @@ class ToolAdapter(PlatformBase):
             tool=tool, platform_host=platform_host, platform_port=platform_port
         )
 
-    def get_adapter_configuration(
+    def _get_adapter_configuration(
         self,
         adapter_instance_id: str,
     ) -> dict[str, Any]:
@@ -49,10 +49,10 @@ class ToolAdapter(PlatformBase):
             using the adapter_instance_id
 
         Args:
-            adapter_instance_id (str): adapter Instance Id
+            adapter_instance_id (str): Adapter instance ID
 
         Returns:
-            Any: _description_
+            dict[str, Any]: Config stored for the adapter
         """
         url = f"{self.base_url}/adapter_instance"
         query_params = {AdapterKeys.ADAPTER_INSTANCE_ID: adapter_instance_id}
@@ -93,13 +93,13 @@ class ToolAdapter(PlatformBase):
         platform service to retrieve the configuration.
 
         Args:
-            adapter_instance_id (str): ID of the adapter instance
             tool (AbstractTool): Instance of AbstractTool
+            adapter_instance_id (str): ID of the adapter instance
         Required env variables:
             PLATFORM_HOST: Host of platform service
             PLATFORM_PORT: Port of platform service
         Returns:
-            Any: engine
+            dict[str, Any]: Config stored for the adapter
         """
         # Check if the adapter ID matches any public adapter keys
         if SdkHelper.is_public_adapter(adapter_id=adapter_instance_id):
@@ -117,4 +117,4 @@ class ToolAdapter(PlatformBase):
             platform_host=platform_host,
             platform_port=platform_port,
         )
-        return tool_adapter.get_adapter_configuration(adapter_instance_id)
+        return tool_adapter._get_adapter_configuration(adapter_instance_id)

--- a/src/unstract/sdk/adapters/utils.py
+++ b/src/unstract/sdk/adapters/utils.py
@@ -31,7 +31,7 @@ class AdapterUtils:
                 if message_key in err_json:
                     return str(err_json[message_key])
             elif err_response.headers["Content-Type"] == "text/plain":
-                return err.response.text  # type: ignore
+                return err_response.text  # type: ignore
         return default_err
 
     @staticmethod

--- a/src/unstract/sdk/tool/executor.py
+++ b/src/unstract/sdk/tool/executor.py
@@ -49,8 +49,9 @@ class ToolExecutor:
             self.tool.stream_error_and_exit("--settings are required for RUN command")
         settings: dict[str, Any] = loads(args.settings)
 
+        tool_name = self.tool.properties["displayName"]
         self.tool.stream_log(
-            f"Running tool with "
+            f"Running tool '{tool_name}' with "
             f"Workflow ID: {self.tool.workflow_id}, "
             f"Execution ID: {self.tool.execution_id}, "
             f"SDK Version: {get_sdk_version()}"
@@ -72,7 +73,8 @@ class ToolExecutor:
                 output_dir=self.tool.get_output_dir(),
             )
         except Exception as e:
-            logger.error(f"Error while tool run: {e}", stack_info=True, exc_info=True)
-            self.tool.stream_error_and_exit(f"Error while running tool: {str(e)}")
+            msg = f"Error while running tool '{tool_name}': {str(e)}"
+            logger.error(msg, stack_info=True, exc_info=True)
+            self.tool.stream_error_and_exit(msg)
 
         # TODO: Call tool method to validate if output was written

--- a/src/unstract/sdk/tool/stream.py
+++ b/src/unstract/sdk/tool/stream.py
@@ -94,7 +94,7 @@ class StreamMixin:
         """
         env_value = os.environ.get(env_key)
         if env_value is None or env_value == "":
-            self.stream_error_and_exit(f"Env variable {env_key} is required")
+            self.stream_error_and_exit(f"Env variable '{env_key}' is required")
         return env_value
 
     @staticmethod


### PR DESCRIPTION
## What

- Error handling improvement for response from platform service
- Minor log update for context during tool run
- Bumped to 0.42.1

## Why

- Existing implementation does not display the error correctly

## How

- Since the SDK is used by tools and other services alike, raising a pythonic error rather than streaming logs alone


## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/567

## Notes on Testing

- Tested along with OSS PR

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
