### PR TITLE
Remove tool id from index key id generation

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.44.0"
+__version__ = "0.45.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -142,8 +142,7 @@ class Index:
         Returns:
             str: A unique ID for the file and indexing arguments combination
         """
-        doc_id = self.generate_file_id(
-            tool_id=tool_id,
+        doc_id = self.generate_index_key(
             vector_db=vector_db_instance_id,
             embedding=embedding_instance_id,
             x2text=x2text_instance_id,
@@ -335,9 +334,8 @@ class Index:
         finally:
             vector_db.close()
 
-    def generate_file_id(
+    def generate_index_key(
         self,
-        tool_id: str,
         vector_db: str,
         embedding: str,
         x2text: str,
@@ -349,7 +347,6 @@ class Index:
         """Generates a unique ID useful for identifying files during indexing.
 
         Args:
-            tool_id (str): Unique ID of the tool or workflow
             vector_db (str): UUID of the vector DB adapter
             embedding (str): UUID of the embedding adapter
             x2text (str): UUID of the X2Text adapter
@@ -373,7 +370,6 @@ class Index:
         # which might not be relevant to indexing. This is easier for now than
         # marking certain keys of the adapter config as necessary.
         index_key = {
-            "tool_id": tool_id,
             "file_hash": file_hash,
             "vector_db_config": ToolAdapter.get_adapter_config(self.tool, vector_db),
             "embedding_config": ToolAdapter.get_adapter_config(self.tool, embedding),
@@ -388,7 +384,28 @@ class Index:
         hashed_index_key = ToolUtils.hash_str(json.dumps(index_key, sort_keys=True))
         return hashed_index_key
 
-    @deprecated("Instantiate Index and call index() instead")
+    @deprecated("Instantiate generate_index_key() instead")
+    def generate_file_id(
+        self,
+        tool_id: str,
+        vector_db: str,
+        embedding: str,
+        x2text: str,
+        chunk_size: str,
+        chunk_overlap: str,
+        file_path: Optional[str] = None,
+        file_hash: Optional[str] = None,
+    ) -> str:
+        self.generate_index_key(
+            vector_db,
+            embedding,
+            x2text,
+            chunk_size,
+            chunk_overlap,
+            file_path,
+            file_hash,
+        )
+
     def index_file(
         self,
         tool_id: str,

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -384,7 +384,7 @@ class Index:
         hashed_index_key = ToolUtils.hash_str(json.dumps(index_key, sort_keys=True))
         return hashed_index_key
 
-    @deprecated("Instantiate generate_index_key() instead")
+    @deprecated(version="0.45.0", reason="Use generate_index_key() instead")
     def generate_file_id(
         self,
         tool_id: str,


### PR DESCRIPTION
## What

Remove tool id from index key id generation

## Why

While generating the doc_id / index key  for indexing, tool id has always been part of it. tool id need not be part of the index key id generation as the indexed documents are not dependent on the tool. Hence it needs to be removed out of the equation

## How

- Deprecate the existing API that takes tool_id as a param while generating index_id
- Introduce a new API without tool id to genertae the index id
- To take care of existing usages of genertae_file_id API, in the implementation, remove the usage of tool_id even though it is passed

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

- For an already indexed doc using the tool_id, after using the new API, it will still go ahead and index it as the index key that generate_index_key is different from the id generated by the now deprecated generate_file_id

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
