### PR TITLE
fix: Fixed import issue with deprecated functions

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.45.0"
+__version__ = "0.45.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapter.py
+++ b/src/unstract/sdk/adapter.py
@@ -78,7 +78,7 @@ class ToolAdapter(PlatformBase):
             msg = AdapterUtils.get_msg_from_request_exc(
                 err=e, message_key="error", default_err=default_err
             )
-            raise SdkError(f"Error while retrieving adapter. {msg}")
+            raise SdkError(f"Error retrieving adapter. {msg}")
         return adapter_data
 
     @staticmethod

--- a/src/unstract/sdk/embedding.py
+++ b/src/unstract/sdk/embedding.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional
 
+from deprecated import deprecated
 from llama_index.core.base.embeddings.base import Embedding
 from llama_index.core.embeddings import BaseEmbedding
-from typing_extensions import deprecated
 
 from unstract.sdk.adapter import ToolAdapter
 from unstract.sdk.adapters.constants import Common
@@ -38,9 +38,7 @@ class Embedding:
             self._length: int = self._get_embedding_length()
             self._usage_kwargs["adapter_instance_id"] = self._adapter_instance_id
 
-            if not SdkHelper.is_public_adapter(
-                adapter_id=self._adapter_instance_id
-            ):
+            if not SdkHelper.is_public_adapter(adapter_id=self._adapter_instance_id):
                 platform_api_key = self._tool.get_env_or_die(ToolEnv.PLATFORM_API_KEY)
                 CallbackManager.set_callback(
                     platform_api_key=platform_api_key,

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Any, Callable, Optional
 
+from deprecated import deprecated
 from llama_index.core import Document
 from llama_index.core.node_parser import SimpleNodeParser
 from llama_index.core.vector_stores import (
@@ -11,7 +12,6 @@ from llama_index.core.vector_stores import (
     VectorStoreQuery,
     VectorStoreQueryResult,
 )
-from typing_extensions import deprecated
 
 from unstract.sdk.adapter import ToolAdapter
 from unstract.sdk.adapters.exceptions import AdapterError

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -2,12 +2,12 @@ import logging
 import re
 from typing import Any, Callable, Optional
 
+from deprecated import deprecated
 from llama_index.core.base.llms.types import CompletionResponseGen
 from llama_index.core.llms import LLM as LlamaIndexLLM
 from llama_index.core.llms import CompletionResponse
 from openai import APIError as OpenAIAPIError
 from openai import RateLimitError as OpenAIRateLimitError
-from typing_extensions import deprecated
 
 from unstract.sdk.adapter import ToolAdapter
 from unstract.sdk.adapters.constants import Common

--- a/src/unstract/sdk/ocr.py
+++ b/src/unstract/sdk/ocr.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta
 from typing import Optional
 
-from typing_extensions import deprecated
+from deprecated import deprecated
 
 from unstract.sdk.adapter import ToolAdapter
 from unstract.sdk.adapters.constants import Common

--- a/src/unstract/sdk/utils/callback_manager.py
+++ b/src/unstract/sdk/utils/callback_manager.py
@@ -2,11 +2,11 @@ import logging
 from typing import Callable, Optional, Union
 
 import tiktoken
+from deprecated import deprecated
 from llama_index.core.callbacks import CallbackManager as LlamaIndexCallbackManager
 from llama_index.core.callbacks import TokenCountingHandler
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.llms import LLM
-from typing_extensions import deprecated
 
 from unstract.sdk.utils.usage_handler import UsageHandler
 

--- a/src/unstract/sdk/vector_db.py
+++ b/src/unstract/sdk/vector_db.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any, Optional, Union
 
+from deprecated import deprecated
 from llama_index.core import StorageContext, VectorStoreIndex
 from llama_index.core.indices.base import IndexType
 from llama_index.core.schema import BaseNode, Document
@@ -10,7 +11,6 @@ from llama_index.core.vector_stores.types import (
     VectorStore,
     VectorStoreQueryResult,
 )
-from typing_extensions import deprecated
 
 from unstract.sdk.adapter import ToolAdapter
 from unstract.sdk.adapters.constants import Common

--- a/src/unstract/sdk/x2txt.py
+++ b/src/unstract/sdk/x2txt.py
@@ -2,7 +2,7 @@ from abc import ABCMeta
 from typing import Any, Optional
 
 import pdfplumber
-from typing_extensions import deprecated
+from deprecated import deprecated
 
 from unstract.sdk.adapter import ToolAdapter
 from unstract.sdk.adapters.constants import Common


### PR DESCRIPTION
## What

- Import issue fix for deprecated functions

## Why

- Imports failed due to an incorrect `deprecated` module which was used
![image](https://github.com/user-attachments/assets/cc2d2af5-f500-42f2-a8bd-0bbfbb2966a5)


## Notes on Testing

- Able to start the backend with no errors


## Checklist

I have read and understood the [Contribution Guidelines]().
