### PR TITLE
Fix deprecated method - generate_file_id for backward compatibility

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.44.0"
+__version__ = "0.45.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.45.1"
+__version__ = "0.45.2"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -142,8 +142,7 @@ class Index:
         Returns:
             str: A unique ID for the file and indexing arguments combination
         """
-        doc_id = self.generate_file_id(
-            tool_id=tool_id,
+        doc_id = self.generate_index_key(
             vector_db=vector_db_instance_id,
             embedding=embedding_instance_id,
             x2text=x2text_instance_id,
@@ -335,9 +334,8 @@ class Index:
         finally:
             vector_db.close()
 
-    def generate_file_id(
+    def generate_index_key(
         self,
-        tool_id: str,
         vector_db: str,
         embedding: str,
         x2text: str,
@@ -349,7 +347,6 @@ class Index:
         """Generates a unique ID useful for identifying files during indexing.
 
         Args:
-            tool_id (str): Unique ID of the tool or workflow
             vector_db (str): UUID of the vector DB adapter
             embedding (str): UUID of the embedding adapter
             x2text (str): UUID of the X2Text adapter
@@ -373,7 +370,6 @@ class Index:
         # which might not be relevant to indexing. This is easier for now than
         # marking certain keys of the adapter config as necessary.
         index_key = {
-            "tool_id": tool_id,
             "file_hash": file_hash,
             "vector_db_config": ToolAdapter.get_adapter_config(self.tool, vector_db),
             "embedding_config": ToolAdapter.get_adapter_config(self.tool, embedding),
@@ -388,7 +384,28 @@ class Index:
         hashed_index_key = ToolUtils.hash_str(json.dumps(index_key, sort_keys=True))
         return hashed_index_key
 
-    @deprecated("Instantiate Index and call index() instead")
+    @deprecated("Instantiate generate_index_key() instead")
+    def generate_file_id(
+        self,
+        tool_id: str,
+        vector_db: str,
+        embedding: str,
+        x2text: str,
+        chunk_size: str,
+        chunk_overlap: str,
+        file_path: Optional[str] = None,
+        file_hash: Optional[str] = None,
+    ) -> str:
+        self.generate_index_key(
+            vector_db,
+            embedding,
+            x2text,
+            chunk_size,
+            chunk_overlap,
+            file_path,
+            file_hash,
+        )
+
     def index_file(
         self,
         tool_id: str,

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -384,7 +384,7 @@ class Index:
         hashed_index_key = ToolUtils.hash_str(json.dumps(index_key, sort_keys=True))
         return hashed_index_key
 
-    @deprecated("Instantiate generate_index_key() instead")
+    @deprecated(version="0.45.0", reason="Use generate_index_key() instead")
     def generate_file_id(
         self,
         tool_id: str,

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -396,7 +396,7 @@ class Index:
         file_path: Optional[str] = None,
         file_hash: Optional[str] = None,
     ) -> str:
-        self.generate_index_key(
+        return self.generate_index_key(
             vector_db,
             embedding,
             x2text,

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,122 @@
+import json
+import logging
+import os
+import unittest
+from typing import Any, Optional
+from unittest.mock import Mock, patch
+
+from dotenv import load_dotenv
+from parameterized import parameterized
+
+from unstract.sdk.index import Index
+from unstract.sdk.tool.base import BaseTool
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+def get_test_values(env_key: str) -> list[str]:
+    test_values = json.loads(os.environ.get(env_key))
+    return test_values
+
+
+class ToolLLMTest(unittest.TestCase):
+    class MockTool(BaseTool):
+        def run(
+            self,
+            params: dict[str, Any] = {},
+            settings: dict[str, Any] = {},
+            workflow_id: str = "",
+        ) -> None:
+            # self.stream_log("Mock tool running")
+            pass
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tool = cls.MockTool()
+
+    @patch(
+        "unstract.sdk.index.Index.generate_index_key",
+        Mock(
+            return_value="77843eb8d9e30ad56bfcb018c2633fa32feef2f0c09762b6b820c75664b64c1b"
+        ),
+    )
+    def test_generate_file_id(self):
+        expected = "77843eb8d9e30ad56bfcb018c2633fa32feef2f0c09762b6b820c75664b64c1b"
+        index = Index(tool=self.tool)
+        actual = index.generate_file_id(
+            tool_id="8ac26867-7811-4dc7-a17b-b16d3b561583",
+            vector_db="81f1f6a8-cae8-4b8e-b2a4-57f80de512f6",
+            embedding="ecf998d6-ded0-4aca-acd1-372a21daf0f9",
+            x2text="59bc55fc-e2a7-48dd-ae93-794b4d81d46e",
+            chunk_size="1024",
+            chunk_overlap="128",
+            file_path="/a/b/c",
+            file_hash="045b1a67824592b67426f8e60c1f8328e8d2a35139f9983e0aa0a7b6f10915c3",
+        )
+        assert expected == actual
+
+    test_data = [
+        {
+            "vector_db": "81f1f6a8-cae8-4b8e-b2a4-57f80de512f6",
+            "embedding": "ecf998d6-ded0-4aca-acd1-372a21daf0f9",
+            "x2text": "59bc55fc-e2a7-48dd-ae93-794b4d81d46e",
+            "chunk_size": "1024",
+            "chunk_overlap": "128",
+            "file_path": "/a/b/c",
+        },
+        {
+            "vector_db": "81f1f6a8-cae8-4b8e-b2a4-57f80de512f6",
+            "embedding": "ecf998d6-ded0-4aca-acd1-372a21daf0f9",
+            "x2text": "59bc55fc-e2a7-48dd-ae93-794b4d81d46e",
+            "chunk_size": "1024",
+            "chunk_overlap": "128",
+            "file_path": "/a/b/c",
+            "file_hash": "045b1a67824592b67426f8e60c1f8328e8d2a35139f9983e0aa0a7b6f10915c3",
+        },
+    ]
+
+    @parameterized.expand(test_data)
+    @patch(
+        "unstract.sdk.adapter.ToolAdapter.get_adapter_config",
+        Mock(return_value={}),
+    )
+    @patch(
+        "unstract.sdk.utils.ToolUtils.hash_str",
+        Mock(
+            return_value="77843eb8d9e30ad56bfcb018c2633fa32feef2f0c09762b6b820c75664b64c1b"
+        ),
+    )
+    @patch(
+        "unstract.sdk.utils.ToolUtils.get_hash_from_file",
+        Mock(
+            return_value="ab940bb34a60d2a7876dd8e1bd1b22f5dc85936a9e2af3c49bfc888a1d944ff0"
+        ),
+    )
+    def test_generate_index_key(
+        self,
+        vector_db: str,
+        embedding: str,
+        x2text: str,
+        chunk_size: str,
+        chunk_overlap: str,
+        file_path: Optional[str] = None,
+        file_hash: Optional[str] = None,
+    ):
+        expected = "77843eb8d9e30ad56bfcb018c2633fa32feef2f0c09762b6b820c75664b64c1b"
+        index = Index(tool=self.tool)
+        actual = index.generate_index_key(
+            vector_db,
+            embedding,
+            x2text,
+            chunk_size,
+            chunk_overlap,
+            file_path,
+            file_hash,
+        )
+        assert expected == actual
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

generate_file_id was deperecated in v0.45.0. However there was a bug in this version causing the function to break. This is fixed in the PR.

## Why

To maintain backward compatibility of deprecated functions

## How

Fix the broken logic

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Added unittests under tests/test_index.py to test the deprecated function generate_file_id() and the newly added alternate generate_index_key()

## Screenshots

![image](https://github.com/user-attachments/assets/11c13037-0b6e-42bd-85a8-192fa54e0c62)


## Checklist

I have read and understood the [Contribution Guidelines]().
