### PR TITLE
extracted text missing for the intial if condition

### DIFF
--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -251,7 +251,7 @@ class Index:
                         output_file_path=output_file_path,
                     )
 
-                    extracted_text = process_response.extracted_text
+                extracted_text = process_response.extracted_text
             except AdapterError as e:
                 # Wrapping AdapterErrors with SdkError
                 raise IndexingError(str(e)) from e


### PR DESCRIPTION
## What

The extracted text was initialized to empty text, which is not getting updated in n enable highlight condition

## Why

The new metadata changes are getting empty extracted text in the enable highlight scenario.

## How

Moved assigning value to extracted_text to one level up.

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
