### PR TITLE
fix: Introduced new index_document() to fix chunking related issue

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.47.0"
+__version__ = "0.48.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/vector_db.py
+++ b/src/unstract/sdk/vector_db.py
@@ -146,7 +146,7 @@ class VectorDB:
             **index_kwargs,
         )
 
-    @deprecated(version="0.46.0", reason="Use index_document() instead")
+    @deprecated(version="0.47.0", reason="Use index_document() instead")
     def get_vector_store_index_from_storage_context(
         self,
         documents: Sequence[Document],


### PR DESCRIPTION
## What

- Deprecated old function `get_vector_store_index_from_storage_context()` to index and created a new one `index_document()` in `vector_db.py`
- Moved attributes within new function to simplify logic at caller side
- Renamed deprecated `SimpleNodeParser` to the intended `SentenceSplitter`
- Bumped SDK to `0.48.0`

## Why

- The llama index function `VectorStoreIndex.from_documents()` expects an attribute `transformations` which was not set correctly. As a result the user configured values for chunk size and chunk overlap was never set and used


## Notes on Testing

- Attempted indexing locally

## Screenshots

1. With 500 and 50 chunk size / overlap
![image](https://github.com/user-attachments/assets/88ed87bb-5584-4b16-b339-bfbf6e3dbc3d)
1. With 2048 and 256 chunk size / overlap
![image](https://github.com/user-attachments/assets/cbadc601-c038-4980-8529-5e84b005789c)


## Checklist

I have read and understood the [Contribution Guidelines]().
