### PR TITLE
[FIX] JSON regex check based on param

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.48.0"
+__version__ = "0.48.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -69,7 +69,7 @@ class LLM:
     def complete(
         self,
         prompt: str,
-        extract_json: bool = False,
+        extract_json: bool = True,
         process_text: Optional[Callable[[str], str]] = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
@@ -79,7 +79,7 @@ class LLM:
             prompt (str): The input text prompt for generating the completion.
             extract_json (bool, optional): If set to True, the response text is
                 processed using a regex to extract JSON content from it. If no JSON is
-                found, the text is returned as it is. Defaults to False.
+                found, the text is returned as it is. Defaults to True.
             process_text (Optional[Callable[[str], str]], optional): A callable that
                 processes the generated text and extracts specific information.
                 Defaults to None.
@@ -194,7 +194,7 @@ class LLM:
         return self._llm_instance.class_name()
 
     def get_model_name(self) -> str:
-        """Gets the name of the LLM model
+        """Gets the name of the LLM model.
 
         Args:
             NA

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -69,24 +69,28 @@ class LLM:
     def complete(
         self,
         prompt: str,
+        extract_json: bool = False,
         process_text: Optional[Callable[[str], str]] = None,
         **kwargs: Any,
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """Generates a completion response for the given prompt.
 
         Args:
             prompt (str): The input text prompt for generating the completion.
+            extract_json (bool, optional): If set to True, the response text is
+                processed using a regex to extract JSON content from it. If no JSON is
+                found, the text is returned as it is. Defaults to False.
             process_text (Optional[Callable[[str], str]], optional): A callable that
                 processes the generated text and extracts specific information.
                 Defaults to None.
             **kwargs (Any): Additional arguments passed to the completion function.
 
         Returns:
-            Optional[dict[str, Any]]: A dictionary containing the result of the
-                completion and processed output or None if the completion fails.
+            dict[str, Any]: A dictionary containing the result of the completion
+                and any processed output.
 
         Raises:
-            Any: If an error occurs during the completion process, it will be
+            LLMError: If an error occurs during the completion process, it will be
                 raised after being processed by `parse_llm_err`.
         """
         try:
@@ -100,9 +104,10 @@ class LLM:
                 except Exception as e:
                     logger.error(f"Error occured inside function 'process_text': {e}")
                     process_text_output = {}
-            match = LLM.json_regex.search(response.text)
-            if match:
-                response.text = match.group(0)
+            if extract_json:
+                match = LLM.json_regex.search(response.text)
+                if match:
+                    response.text = match.group(0)
             return {LLM.RESPONSE: response, **process_text_output}
         except Exception as e:
             raise parse_llm_err(e) from e


### PR DESCRIPTION
## What

JSON regex check based on param

## Why

The JSON regex check is based on matching characters like `[,]` or `{,}`. If there are pairs of these brackets within the response, the function will extract only the content between the matching brackets even if it is not a JSON.

## How

Added a parameter `extract_json`, which uses a regex to extract content only if it is set to True

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
