### PR TITLE
[FIX] Delete Vector DB nodes after extraction

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.48.1"
+__version__ = "0.48.2"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -203,20 +203,7 @@ class Index:
                     level=LogLevel.ERROR,
                 )
 
-            if doc_id_found and reindex:
-                # Delete the nodes for the doc_id
-                try:
-                    vector_db.delete(ref_doc_id=doc_id)
-                    self.tool.stream_log(f"Deleted nodes for {doc_id}")
-                except Exception as e:
-                    self.tool.stream_log(
-                        f"Error deleting nodes for {doc_id}: {e}",
-                        level=LogLevel.ERROR,
-                    )
-                    raise SdkError(f"Error deleting nodes for {doc_id}: {e}") from e
-                doc_id_found = False
-
-            if doc_id_found:
+            if doc_id_found and not reindex:
                 self.tool.stream_log(f"File was indexed already under {doc_id}")
                 return doc_id
 
@@ -286,6 +273,18 @@ class Index:
                 document.id_ = doc_id
                 documents.append(document)
             self.tool.stream_log(f"Number of documents: {len(documents)}")
+
+            if doc_id_found:
+                # Delete the nodes for the doc_id
+                try:
+                    vector_db.delete(ref_doc_id=doc_id)
+                    self.tool.stream_log(f"Deleted nodes for {doc_id}")
+                except Exception as e:
+                    self.tool.stream_log(
+                        f"Error deleting nodes for {doc_id}: {e}",
+                        level=LogLevel.ERROR,
+                    )
+                    raise SdkError(f"Error deleting nodes for {doc_id}: {e}") from e
 
             try:
                 if chunk_size == 0:


### PR DESCRIPTION
## What

- Delete Vector DB nodes after extraction

## Why

- If same file in workflow, reindex of one call deletes the vector db node if found and then proceeds extraction. Since extraction is a time consuming process existing node should not be deleted before extraction. Else during this time, if we try to read the vector db the node won't be available.

## How

- Delete the node only after extraction in case of `reindex=True`.

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
