### PR TITLE
Pass in httpx client in Azure OpenAI embedding initialisation & increase default timeouts

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.48.2"
+__version__ = "0.48.3"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.48.3"
+__version__ = "0.49.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapters/embedding/azure_open_ai/src/azure_open_ai.py
+++ b/src/unstract/sdk/adapters/embedding/azure_open_ai/src/azure_open_ai.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any
 
+import httpx
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
 
@@ -18,7 +19,7 @@ class Constants:
     DEPLOYMENT_NAME = "deployment_name"
     API_TYPE = "azure"
     TIMEOUT = "timeout"
-    DEFAULT_TIMEOUT = 60
+    DEFAULT_TIMEOUT = 240
 
 
 class AzureOpenAI(EmbeddingAdapter):
@@ -59,6 +60,8 @@ class AzureOpenAI(EmbeddingAdapter):
                 config=self.config
             )
             timeout = int(self.config.get(Constants.TIMEOUT, Constants.DEFAULT_TIMEOUT))
+            httpx_timeout = httpx.Timeout(10.0, connect=60.0)
+            httpx_client = httpx.Client(timeout=httpx_timeout)
             embedding: BaseEmbedding = AzureOpenAIEmbedding(
                 model=str(self.config.get(Constants.MODEL)),
                 deployment_name=str(self.config.get(Constants.DEPLOYMENT_NAME)),
@@ -68,6 +71,7 @@ class AzureOpenAI(EmbeddingAdapter):
                 embed_batch_size=embedding_batch_size,
                 api_type=Constants.API_TYPE,
                 timeout=timeout,
+                http_client=httpx_client,
             )
             return embedding
         except Exception as e:

--- a/src/unstract/sdk/adapters/embedding/azure_open_ai/src/azure_open_ai.py
+++ b/src/unstract/sdk/adapters/embedding/azure_open_ai/src/azure_open_ai.py
@@ -60,7 +60,7 @@ class AzureOpenAI(EmbeddingAdapter):
                 config=self.config
             )
             timeout = int(self.config.get(Constants.TIMEOUT, Constants.DEFAULT_TIMEOUT))
-            httpx_timeout = httpx.Timeout(10.0, connect=60.0)
+            httpx_timeout = httpx.Timeout(timeout, connect=60.0)
             httpx_client = httpx.Client(timeout=httpx_timeout)
             embedding: BaseEmbedding = AzureOpenAIEmbedding(
                 model=str(self.config.get(Constants.MODEL)),

--- a/src/unstract/sdk/adapters/embedding/azure_open_ai/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/embedding/azure_open_ai/src/static/json_schema.json
@@ -59,7 +59,7 @@
       "minimum": 0,
       "multipleOf": 1,
       "title": "Timeout",
-      "default": 60,
+      "default": 240,
       "description": "Timeout for each request in seconds"
     }
   }

--- a/src/unstract/sdk/adapters/embedding/open_ai/src/open_ai.py
+++ b/src/unstract/sdk/adapters/embedding/open_ai/src/open_ai.py
@@ -16,7 +16,7 @@ class Constants:
     ADAPTER_NAME = "adapter_name"
     API_TYPE = "openai"
     TIMEOUT = "timeout"
-    DEFAULT_TIMEOUT = 60
+    DEFAULT_TIMEOUT = 240
 
 
 class OpenAI(EmbeddingAdapter):

--- a/src/unstract/sdk/adapters/embedding/open_ai/src/open_ai.py
+++ b/src/unstract/sdk/adapters/embedding/open_ai/src/open_ai.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any
 
+import httpx
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
 
@@ -54,6 +55,8 @@ class OpenAI(EmbeddingAdapter):
     def get_embedding_instance(self) -> BaseEmbedding:
         try:
             timeout = int(self.config.get(Constants.TIMEOUT, Constants.DEFAULT_TIMEOUT))
+            httpx_timeout = httpx.Timeout(10.0, connect=60.0)
+            httpx_client = httpx.Client(timeout=httpx_timeout)
             embedding: BaseEmbedding = OpenAIEmbedding(
                 api_key=str(self.config.get(Constants.API_KEY)),
                 api_base=str(
@@ -61,6 +64,7 @@ class OpenAI(EmbeddingAdapter):
                 ),
                 api_type=Constants.API_TYPE,
                 timeout=timeout,
+                http_client=httpx_client,
             )
             return embedding
         except Exception as e:

--- a/src/unstract/sdk/adapters/embedding/open_ai/src/open_ai.py
+++ b/src/unstract/sdk/adapters/embedding/open_ai/src/open_ai.py
@@ -12,6 +12,7 @@ from unstract.sdk.adapters.exceptions import AdapterError
 
 class Constants:
     API_KEY = "api_key"
+    MODEL = "model"
     API_BASE_VALUE = "https://api.openai.com/v1/"
     API_BASE_KEY = "api_base"
     ADAPTER_NAME = "adapter_name"
@@ -62,6 +63,7 @@ class OpenAI(EmbeddingAdapter):
                 api_base=str(
                     self.config.get(Constants.API_BASE_KEY, Constants.API_BASE_VALUE)
                 ),
+                model=str(self.config.get(Constants.MODEL)),
                 api_type=Constants.API_TYPE,
                 timeout=timeout,
                 http_client=httpx_client,

--- a/src/unstract/sdk/adapters/embedding/open_ai/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/embedding/open_ai/src/static/json_schema.json
@@ -12,6 +12,12 @@
       "default": "",
       "description": "Provide a unique name for this adapter instance. Example: openai-emb-1"
     },
+    "model": {
+      "type": "string",
+      "title": "Model",
+      "default": "text-embedding-ada-002",
+      "description": "Provide the name of the model."
+    },
     "api_key": {
       "type": "string",
       "title": "API Key",

--- a/src/unstract/sdk/adapters/embedding/open_ai/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/embedding/open_ai/src/static/json_schema.json
@@ -36,7 +36,7 @@
       "minimum": 0,
       "multipleOf": 1,
       "title": "Timeout",
-      "default": 60,
+      "default": 240,
       "description": "Timeout in seconds"
     }
   }


### PR DESCRIPTION
## What

1. Pass in httpx client in Azure embedding initialization 
2.  Increase default timeouts

## Why

To address cases where we see a timeout while embedding

## How

Create a httpx client and pass it in embedding initialization for Azure OpenAI

## Relevant Docs

- https://www.python-httpx.org/advanced/timeouts/

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Created AzureOpenAI and OpenaAI using the new timeouts and prompt studio was tested for these 2 profiles. as documented below.

## Screenshots

Increased timeout to 240 seconds for Azure Embedding
![image](https://github.com/user-attachments/assets/c1c4de6c-d07a-473a-b50d-3c2a99bc59ca)

Added model field to OpenAI embedding & increased timeout to 240 for default in 
![image](https://github.com/user-attachments/assets/9a2f275b-88bd-4fb2-8725-ee1638bdc4af)

Prompt run for the 2 embedding profiles
Left one is using AzureOpenAI and the right one is using OpenAI embedding
![image](https://github.com/user-attachments/assets/5fc44a1b-ba2d-4de9-a225-fa725619206f)

![image](https://github.com/user-attachments/assets/c316ee52-7980-4b50-9445-28c3d56e8aa0)

## Checklist

I have read and understood the [Contribution Guidelines]().
