### PR TITLE
feat: Minor log enhancement - tool version included

### DIFF
--- a/src/unstract/sdk/tool/entrypoint.py
+++ b/src/unstract/sdk/tool/entrypoint.py
@@ -1,6 +1,3 @@
-import os
-
-from unstract.sdk.constants import ToolEnv
 from unstract.sdk.tool.base import BaseTool
 from unstract.sdk.tool.executor import ToolExecutor
 from unstract.sdk.tool.parser import ToolArgsParser
@@ -20,8 +17,6 @@ class ToolEntrypoint:
             tool (AbstractTool): Tool to execute
             args (List[str]): Arguments passed to a tool
         """
-        # Implicitly set to indicate that the SDK is run from a tool
-        os.environ[ToolEnv.EXECUTION_BY_TOOL] = "True"
         parsed_args = ToolArgsParser.parse_args(args)
         executor = ToolExecutor(tool=tool)
         executor.execute(parsed_args)

--- a/src/unstract/sdk/tool/executor.py
+++ b/src/unstract/sdk/tool/executor.py
@@ -50,8 +50,9 @@ class ToolExecutor:
         settings: dict[str, Any] = loads(args.settings)
 
         tool_name = self.tool.properties["displayName"]
+        tool_version = self.tool.properties["toolVersion"]
         self.tool.stream_log(
-            f"Running tool '{tool_name}' with "
+            f"Running tool '{tool_name}:{tool_version}' with "
             f"Workflow ID: {self.tool.workflow_id}, "
             f"Execution ID: {self.tool.execution_id}, "
             f"SDK Version: {get_sdk_version()}"


### PR DESCRIPTION
## What

- Included tool version also in the initial tool run log
- Removed a scenario where an env `EXECUTION_BY_TOOL` was set
- SDK version is not bumped and can be clubbed with any subsequent release

## Why

- More context -> to avoid asking user / checking releases to figure this out
- `EXECUTION_BY_TOOL` is set and passed by the runner before the tool starts as it should be


## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/683

## Notes on Testing

- Env removal tested along with https://github.com/Zipstack/unstract/pull/683
- Tool version log was also checked



## Checklist

I have read and understood the [Contribution Guidelines]().
