### PR TITLE
fix: OpenAI error handling fixing for None type error

### DIFF
--- a/src/unstract/sdk/adapters/llm/open_ai/src/open_ai.py
+++ b/src/unstract/sdk/adapters/llm/open_ai/src/open_ai.py
@@ -91,7 +91,7 @@ class OpenAILLM(LLMAdapter):
             LLMError: Error to be sent to the user
         """
         msg = "Error from OpenAI. "
-        if hasattr(e, "body") and "message" in e.body:
+        if hasattr(e, "body") and isinstance(e.body, dict) and "message" in e.body:
             msg += e.body["message"]
         else:
             msg += e.message

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -245,7 +245,7 @@ class LLM:
         except OpenAIAPIError as e:
             msg = "OpenAI error: "
             msg += e.message
-            if hasattr(e, "body") and "message" in e.body:
+            if hasattr(e, "body") and isinstance(e.body, dict) and "message" in e.body:
                 msg += e.body["message"]
             if isinstance(e, OpenAIRateLimitError):
                 raise RateLimitError(msg)


### PR DESCRIPTION
## What

- Error handling fix for None type errors

## Why

```
2024-10-16 10:05:09.794	
````
2024-10-16 10:05:09.794	
TypeError: argument of type 'NoneType' is not iterable
2024-10-16 10:05:09.794	
    if hasattr(e, "body") and "message" in e.body:
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/unstract/sdk/adapters/llm/open_ai/src/open_ai.py", line 94, in parse_llm_err
2024-10-16 10:05:09.794	
    return OpenAILLM.parse_llm_err(e)
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/unstract/sdk/adapters/llm/exceptions.py", line 30, in parse_llm_err
2024-10-16 10:05:09.794	
    raise parse_llm_err(e) from e
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/unstract/sdk/llm.py", line 113, in complete
2024-10-16 10:05:09.794	
    completion = llm.complete(
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/unstract/prompt_service/helper.py", line 327, in run_completion
2024-10-16 10:05:09.794	
    return run_completion(
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/unstract/prompt_service/helper.py", line 273, in construct_and_run_prompt
2024-10-16 10:05:09.794	
    answer = construct_and_run_prompt(
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/unstract/prompt_service/main.py", line 374, in prompt_processor
2024-10-16 10:05:09.794	
    return func(*args, **kwargs)
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/unstract/prompt_service/main.py", line 95, in wrapper
2024-10-16 10:05:09.794	
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/flask/app.py", line 865, in dispatch_request
2024-10-16 10:05:09.794	
    rv = self.dispatch_request()
2024-10-16 10:05:09.794	
  File "/app/.venv/lib/python3.9/site-packages/flask/app.py", line 880, in full_dispatch_request
2024-10-16 10:05:09.794	
Traceback (most recent call last):
```


## How

- Check for error's type beforehand 


## Notes on Testing

- Did not explicitly test it but minor logical change which should fix the error

## Checklist

I have read and understood the [Contribution Guidelines]().
