### PR TITLE
fix: Added default model to openAI embedding to fix None type attribute error

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.52.0"
+__version__ = "0.52.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapters/embedding/open_ai/src/open_ai.py
+++ b/src/unstract/sdk/adapters/embedding/open_ai/src/open_ai.py
@@ -19,6 +19,7 @@ class Constants:
     API_TYPE = "openai"
     TIMEOUT = "timeout"
     DEFAULT_TIMEOUT = 240
+    DEFAULT_MODEL = "text-embedding-ada-002"
 
 
 class OpenAI(EmbeddingAdapter):
@@ -63,7 +64,7 @@ class OpenAI(EmbeddingAdapter):
                 api_base=str(
                     self.config.get(Constants.API_BASE_KEY, Constants.API_BASE_VALUE)
                 ),
-                model=str(self.config.get(Constants.MODEL)),
+                model=str(self.config.get(Constants.MODEL, Constants.DEFAULT_MODEL)),
                 api_type=Constants.API_TYPE,
                 timeout=timeout,
                 http_client=httpx_client,


### PR DESCRIPTION
## What

- Added default `model` for OpenAI embedding
- Bumped SDK version to `0.52.1`

## Why

![image](https://github.com/user-attachments/assets/7191f288-99be-473e-bae3-e4635981e1b8)


## Notes on Testing

- No explicit testing done since its a minor logical fix


## Checklist

I have read and understood the [Contribution Guidelines]().
