### PR TITLE
Support OFF as a threshold value for Safety settings in Vertex AI

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.52.0"
+__version__ = "0.53.0"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapters/llm/vertex_ai/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/llm/vertex_ai/src/static/json_schema.json
@@ -113,7 +113,8 @@
             "BLOCK_LOW_AND_ABOVE",
             "BLOCK_MEDIUM_AND_ABOVE",
             "BLOCK_ONLY_HIGH",
-            "BLOCK_NONE"
+            "BLOCK_NONE",
+            "OFF"
           ],
           "default": "BLOCK_ONLY_HIGH",
           "description": "Settings for HARM_CATEGORY_OTHER"

--- a/src/unstract/sdk/adapters/llm/vertex_ai/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/llm/vertex_ai/src/static/json_schema.json
@@ -61,7 +61,8 @@
             "BLOCK_LOW_AND_ABOVE",
             "BLOCK_MEDIUM_AND_ABOVE",
             "BLOCK_ONLY_HIGH",
-            "BLOCK_NONE"
+            "BLOCK_NONE",
+            "OFF"
           ],
           "default": "BLOCK_ONLY_HIGH",
           "description": "Settings for HARM_CATEGORY_DANGEROUS_CONTENT"
@@ -74,7 +75,8 @@
             "BLOCK_LOW_AND_ABOVE",
             "BLOCK_MEDIUM_AND_ABOVE",
             "BLOCK_ONLY_HIGH",
-            "BLOCK_NONE"
+            "BLOCK_NONE",
+            "OFF"
           ],
           "default": "BLOCK_ONLY_HIGH",
           "description": "Settings for HARM_CATEGORY_HATE_SPEECH"
@@ -87,7 +89,8 @@
             "BLOCK_LOW_AND_ABOVE",
             "BLOCK_MEDIUM_AND_ABOVE",
             "BLOCK_ONLY_HIGH",
-            "BLOCK_NONE"
+            "BLOCK_NONE",
+            "OFF"
           ],
           "default": "BLOCK_ONLY_HIGH",
           "description": "Settings for HARM_CATEGORY_HARASSMENT"
@@ -100,7 +103,8 @@
             "BLOCK_LOW_AND_ABOVE",
             "BLOCK_MEDIUM_AND_ABOVE",
             "BLOCK_ONLY_HIGH",
-            "BLOCK_NONE"
+            "BLOCK_NONE",
+            "OFF"
           ],
           "default": "BLOCK_ONLY_HIGH",
           "description": "Settings for HARM_CATEGORY_SEXUAL_CONTENT"

--- a/src/unstract/sdk/adapters/llm/vertex_ai/src/vertex_ai.py
+++ b/src/unstract/sdk/adapters/llm/vertex_ai/src/vertex_ai.py
@@ -45,6 +45,7 @@ UNSTRACT_VERTEX_SAFETY_THRESHOLD_MAPPING: dict[str, HarmBlockThreshold] = {
     "BLOCK_MEDIUM_AND_ABOVE": HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
     "BLOCK_ONLY_HIGH": HarmBlockThreshold.BLOCK_ONLY_HIGH,
     "BLOCK_NONE": HarmBlockThreshold.BLOCK_NONE,
+    "OFF": HarmBlockThreshold.OFF,
 }
 
 


### PR DESCRIPTION
## What

Vertex AI has the option of setting safety threshold limits. This PR has changes to extend the list of values that are supported for this. Going forwrd, OFF is also a value which means that no safety settings will be applied.

## Why

To disable any safety guideline regulation on the answers that LLM returns.

## How

Include "OFF" as one of the supported values.

## Relevant Docs

- https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-filters#how_to_configure_safety_filters

## Related Issues or PRs

- NA

## Dependencies Versions / Env Variables

-

## Notes on Testing

- Use UI to configure vertex AI without safety threshold....

## Screenshots

![image](https://github.com/user-attachments/assets/ee7195b8-4232-496e-baf6-a24bc9080046)

![image](https://github.com/user-attachments/assets/e84656ec-5afa-4d1d-a3d2-621fe3ebe6c7)

![image](https://github.com/user-attachments/assets/be2ee4d1-8b39-490d-b96f-6f74b8c02abf)



## Checklist

I have read and understood the [Contribution Guidelines]().
