### PR TITLE
fix: Fix/update llmwv2 json schema for 0.53.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,6 @@ unstract-sdk @ git+https://github.com/Zipstack/unstract-sdk@feature-branch
 
 - Or try installing a [local PyPI server](https://pypi.org/project/pypiserver/) and upload / download your package from this server
 
-### Environment variables required for various LLMs (deprecated)
-
-- Azure OpenAI
-  - `OPENAI_API_KEY`
-  - `OPENAI_API_BASE`
-  - `OPENAI_API_VERSION`
-  - `OPENAI_API_ENGINE`
-  - `OPENAI_API_MODEL`
 
 ### Documentation generation
 

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.53.0"
+__version__ = "0.53.1"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer_v2/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer_v2/src/static/json_schema.json
@@ -17,14 +17,14 @@
       "type": "string",
       "title": "URL",
       "format": "uri",
-      "default": "https://llmwhisperer-api.unstract.com",
-      "description": "Provide the URL of the LLM Whisperer service."
+      "default": "https://llmwhisperer-api.us-central.unstract.com",
+      "description": "Provide the base URL of the LLM Whisperer service based on your region."
     },
     "unstract_key": {
       "type": "string",
       "title": "Unstract Key",
       "format": "password",
-      "description": "API key obtained from the Unstract developer portal (https://us-central.unstract.com/llm-whisperer)"
+      "description": "API key obtained from the Unstract developer portal (https://us-central.unstract.com/landing?selectedProduct=llm-whisperer)"
     },
     "mode": {
       "type": "string",

--- a/src/unstract/sdk/adapters/x2text/llm_whisperer_v2/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer_v2/src/static/json_schema.json
@@ -36,7 +36,7 @@
         "form"
       ],
       "default": "form",
-      "description": "Native text : Extract text from native text PDFs. (not scanned). Use this mode when:  You have low latency requirement, All documents are PDFs, PDFs are native text PDFs, Cost sensitive application\n Low cost : Cost effective extraction. Use this mode when:  High quality scanned PDFs,  High quality scanned images, No handwritten documents  \n High quality : High quality extraction. Use this mode when: Medium/low quality scanned PDFs, Medium/low quality scanned images, Handwritten documents \n Form: High quality extraction + Checkbox and Radio button detection. Use this mode when: Checkbox and radio button detection, Medium/low quality scanned PDFs, Medium/low quality scanned images, Handwritten documents."
+      "description": "Processing mode to use, described in the LLM Whisperer documentation (https://docs.unstract.com/llmwhisperer/llm_whisperer/apis/llm_whisperer_text_extraction_api/#modes)."
     },
     "output_mode": {
       "type": "string",
@@ -46,7 +46,7 @@
         "text"
       ],
       "default": "layout_preserving",
-      "description": "The output format. Valid options are layout_preserving and text. Layout preserving mode tries to extract the text from the document as is, maintaining the structural layout of the document. This works very well for LLM consumption. Text (text) mode extracts the text from the document without applying any processing or intelligence. This mode is useful when the layout_preserving mode is not able to extract the text properly. This can happen if the document contains too many different fonts and font sizes."
+      "description": "Output format, described in the LLM Whisperer documentation (https://docs.unstract.com/llmwhisperer/llm_whisperer/apis/llm_whisperer_text_extraction_api/#output-modes)"
     },
     "line_splitter_tolerance": {
       "type": "number",

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -37,15 +37,14 @@ class LLM:
         adapter_instance_id: Optional[str] = None,
         usage_kwargs: dict[Any, Any] = {},
     ):
-        """
-
-        Notes:
-            - "Azure OpenAI" : Environment variables required
-            OPENAI_API_KEY,OPENAI_API_BASE, OPENAI_API_VERSION,
-            OPENAI_API_ENGINE, OPENAI_API_MODEL
+        """Creates an instance of this LLM class.
 
         Args:
-            tool (AbstractTool): Instance of AbstractTool
+            tool (BaseTool): Instance of BaseTool to expose function to stream logs
+            adapter_instance_id (Optional[str], optional): UUID of the adapter in
+                Unstract. Defaults to None.
+            usage_kwargs (dict[Any, Any], optional): Dict to capture token usage with
+                callbacks. Defaults to {}.
         """
         self._tool = tool
         self._adapter_instance_id = adapter_instance_id


### PR DESCRIPTION
## What
- Updated LLMW v2 related URLs in its JSON schema
- Removed mentions of unused OPENAI related envs
- Bumped version to `0.53.1`

## Why

- The default URL shown does not apply to LLMW v2

## Notes on Testing

- Checked the URL that appeared during adapter creation

## Screenshots
![image](https://github.com/user-attachments/assets/d1cf900a-031e-444b-aa8a-a0e65d17d6cd)

## Checklist

I have read and understood the [Contribution Guidelines]().
