### PR TITLE
fix: Added retries for whisper-status API in LLMW v2

### DIFF
--- a/src/unstract/sdk/adapters/x2text/llm_whisperer_v2/src/constants.py
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer_v2/src/constants.py
@@ -42,10 +42,13 @@ class WhispererEnv:
             LLMWhisperer's status API. Defaults to 30s
         MAX_POLLS: Total number of times to poll the status API.
             Set to -1 to poll indefinitely. Defaults to -1
+        STATUS_RETRIES: Number of times to retry calling LLLMWhisperer's status API
+            on failure during polling. Defaults to 5.
     """
 
     POLL_INTERVAL = "ADAPTER_LLMW_POLL_INTERVAL"
     MAX_POLLS = "ADAPTER_LLMW_MAX_POLLS"
+    STATUS_RETRIES = "ADAPTER_LLMW_STATUS_RETRIES"
 
 
 class WhispererConfig:
@@ -94,6 +97,7 @@ class WhispererDefaults:
     HORIZONTAL_STRETCH_FACTOR = 1.0
     POLL_INTERVAL = int(os.getenv(WhispererEnv.POLL_INTERVAL, 30))
     MAX_POLLS = int(os.getenv(WhispererEnv.MAX_POLLS, 30))
+    STATUS_RETRIES = int(os.getenv(WhispererEnv.STATUS_RETRIES, 5))
     PAGES_TO_EXTRACT = ""
     PAGE_SEPARATOR = "<<<"
     MARK_VERTICAL_LINES = False

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -23,7 +23,7 @@ from unstract.sdk.adapters.x2text.dto import TextExtractionResult
 from unstract.sdk.adapters.x2text.llm_whisperer.src import LLMWhisperer
 from unstract.sdk.constants import LogLevel
 from unstract.sdk.embedding import Embedding
-from unstract.sdk.exceptions import IndexingError, SdkError
+from unstract.sdk.exceptions import IndexingError, SdkError, X2TextError
 from unstract.sdk.file_storage import FileStorage, FileStorageProvider
 from unstract.sdk.tool.base import BaseTool
 from unstract.sdk.utils import ToolUtils
@@ -144,13 +144,13 @@ class Index:
         """
         self.tool.stream_log("Extracting text from input file")
         extracted_text = ""
+        x2text = X2Text(
+            tool=self.tool,
+            adapter_instance_id=x2text_instance_id,
+            usage_kwargs=usage_kwargs,
+        )
         try:
-            x2text = X2Text(
-                tool=self.tool,
-                adapter_instance_id=x2text_instance_id,
-                usage_kwargs=usage_kwargs,
-            )
-            if enable_highlight and isinstance(x2text._x2text_instance, LLMWhisperer):
+            if enable_highlight and isinstance(x2text.x2text_instance, LLMWhisperer):
                 process_response: TextExtractionResult = x2text.process(
                     input_file_path=file_path,
                     output_file_path=output_file_path,
@@ -158,20 +158,18 @@ class Index:
                     fs=fs,
                 )
                 whisper_hash_value = process_response.extraction_metadata.whisper_hash
-
                 metadata = {X2TextConstants.WHISPER_HASH: whisper_hash_value}
-
                 self.tool.update_exec_metadata(metadata)
-
             else:
                 process_response: TextExtractionResult = x2text.process(
                     input_file_path=file_path, output_file_path=output_file_path, fs=fs
                 )
-
             extracted_text = process_response.extracted_text
+        # TODO: Handle prepend of context where error is raised and remove this
         except AdapterError as e:
-            # Wrapping AdapterErrors with SdkError
-            raise IndexingError(str(e)) from e
+            msg = f"Error from text extractor '{x2text.x2text_instance.get_name()}'. "
+            msg += str(e)
+            raise X2TextError(msg) from e
         if process_text:
             try:
                 result = process_text(extracted_text)
@@ -180,7 +178,10 @@ class Index:
                 else:
                     logger.warning("'process_text' is expected to return an 'str'")
             except Exception as e:
-                logger.error(f"Error occured inside function 'process_text': {e}")
+                logger.error(
+                    f"Error occured inside callable 'process_text': {e}\n"
+                    "continuing processing..."
+                )
         return extracted_text
 
     @log_elapsed(operation="CHECK_AND_INDEX(overall)")

--- a/src/unstract/sdk/x2txt.py
+++ b/src/unstract/sdk/x2txt.py
@@ -36,6 +36,10 @@ class X2Text(metaclass=ABCMeta):
         self._usage_kwargs = usage_kwargs
         self._initialise()
 
+    @property
+    def x2text_instance(self):
+        return self._x2text_instance
+
     def _initialise(self):
         if self._adapter_instance_id:
             self._x2text_instance = self._get_x2text()
@@ -43,9 +47,7 @@ class X2Text(metaclass=ABCMeta):
     def _get_x2text(self) -> X2TextAdapter:
         try:
             if not self._adapter_instance_id:
-                raise X2TextError(
-                    "Adapter instance ID not set. " "Initialisation failed"
-                )
+                raise X2TextError("Adapter instance ID not set. Initialisation failed")
 
             x2text_config = ToolAdapter.get_adapter_config(
                 self._tool, self._adapter_instance_id


### PR DESCRIPTION
## What
- Retry logic for `/whisper-status` (defaults to 5), configurable by env
- Minor error handling improvement to indicate some context on errors during indexing

## Why

- LLMW had an issue where the whisper-status returned a non 200 response sometimes and we failed immediately. This PR aims to allow some retries before considering a failure


## Dependencies Versions / Env Variables

- `ADAPTER_LLMW_STATUS_RETRIES` -> defaults to 5 if not defined

## Notes on Testing

- Tried generating an error from the code and observed this retry logic kicking in

## Screenshots
![image](https://github.com/user-attachments/assets/7b85071d-f8a8-409a-bf58-e421ac14bd70)

## Checklist

I have read and understood the [Contribution Guidelines]().
