### PR TITLE
fix: Fixed parse_llm_err by passing the LLM adapter class correctly

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.54.0rc6"
+__version__ = "0.54.0rc7"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/llm.py
+++ b/src/unstract/sdk/llm.py
@@ -109,7 +109,7 @@ class LLM:
                     process_text_output = {}
             return {LLM.RESPONSE: response, **process_text_output}
         except Exception as e:
-            raise parse_llm_err(e, self._llm_instance) from e
+            raise parse_llm_err(e, self._llm_adapter_class) from e
 
     def stream_complete(
         self,
@@ -122,7 +122,7 @@ class LLM:
             )
             return response
         except Exception as e:
-            raise parse_llm_err(e, self._llm_instance) from e
+            raise parse_llm_err(e, self._llm_adapter_class) from e
 
     def _get_llm(self, adapter_instance_id: str) -> LlamaIndexLLM:
         """Returns the LLM object for the tool.
@@ -147,9 +147,9 @@ class LLM:
                 Common.ADAPTER
             ]
             llm_metadata = llm_config_data.get(Common.ADAPTER_METADATA)
-            llm_adapter_class: LLMAdapter = llm_adapter(llm_metadata)
-            self._usage_kwargs["provider"] = llm_adapter_class.get_provider()
-            llm_instance: LLM = llm_adapter_class.get_llm_instance()
+            self._llm_adapter_class: LLMAdapter = llm_adapter(llm_metadata)
+            self._usage_kwargs["provider"] = self._llm_adapter_class.get_provider()
+            llm_instance: LLM = self._llm_adapter_class.get_llm_instance()
             return llm_instance
         except Exception as e:
             self._tool.stream_log(


### PR DESCRIPTION
## What
- Passed the LLM adapter class that is expected by `parse_llm_err()`
- Bumped SDK to `rc7`

## Why

- Previously a llama index class was passed that resulted in the below error
![image](https://github.com/user-attachments/assets/71448642-81b7-49ab-874f-331858d554af)


## Related Issues or PRs

- Fixed issue with #120 


## Notes on Testing

- Tried it locally to ensure the correct gets raised

## Checklist

I have read and understood the [Contribution Guidelines]().
