### PR TITLE
fixed connection closing prematurely in index.py

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.54.0rc10"
+__version__ = "0.54.0rc11"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -89,17 +89,8 @@ class Index:
                 filters=filters,
                 similarity_top_k=Constants.TOP_K,
             )
-        except Exception as e:
-            self.tool.stream_log(
-                f"Error building query {vector_db}: {e}", level=LogLevel.ERROR
-            )
-            raise VectorDBError(
-                f"Error building query for {vector_db}: {e}", actual_err=e
-            )
-        finally:
-            vector_db.close()
 
-        try:
+            # Execute query with the open connection
             n: VectorStoreQueryResult = vector_db.query(query=q)
             if len(n.nodes) > 0:
                 self.tool.stream_log(f"Found {len(n.nodes)} nodes for {doc_id}")
@@ -110,7 +101,16 @@ class Index:
             else:
                 self.tool.stream_log(f"No nodes found for {doc_id}")
                 return None
+
+        except Exception as e:
+            self.tool.stream_log(
+                f"Error building query {vector_db}: {e}", level=LogLevel.ERROR
+            )
+            raise VectorDBError(
+                f"Error building query for {vector_db}: {e}", actual_err=e
+            )
         finally:
+            # Close connection only once at the end
             vector_db.close()
 
     @log_elapsed(operation="EXTRACTION")

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -72,45 +72,50 @@ class Index:
         )
 
         try:
-            self.tool.stream_log(
-                f">>> Querying '{vector_db_instance_id}' for {doc_id}..."
-            )
-            doc_id_eq_filter = MetadataFilter.from_dict(
-                {
-                    "key": "doc_id",
-                    "operator": FilterOperator.EQ,
-                    "value": doc_id,
-                }
-            )
-            filters = MetadataFilters(filters=[doc_id_eq_filter])
-            q = VectorStoreQuery(
-                query_embedding=embedding.get_query_embedding(" "),
-                doc_ids=[doc_id],
-                filters=filters,
-                similarity_top_k=Constants.TOP_K,
-            )
-
-            # Execute query with the open connection
-            n: VectorStoreQueryResult = vector_db.query(query=q)
-            if len(n.nodes) > 0:
-                self.tool.stream_log(f"Found {len(n.nodes)} nodes for {doc_id}")
-                all_text = ""
-                for node in n.nodes:
-                    all_text += node.get_content()
-                return all_text
-            else:
-                self.tool.stream_log(f"No nodes found for {doc_id}")
-                return None
-
-        except Exception as e:
-            self.tool.stream_log(
-                f"Error building query {vector_db}: {e}", level=LogLevel.ERROR
-            )
-            raise VectorDBError(
-                f"Error building query for {vector_db}: {e}", actual_err=e
-            )
+            try:
+                self.tool.stream_log(
+                    f">>> Querying '{vector_db_instance_id}' for {doc_id}..."
+                )
+                doc_id_eq_filter = MetadataFilter.from_dict(
+                    {
+                        "key": "doc_id",
+                        "operator": FilterOperator.EQ,
+                        "value": doc_id,
+                    }
+                )
+                filters = MetadataFilters(filters=[doc_id_eq_filter])
+                q = VectorStoreQuery(
+                    query_embedding=embedding.get_query_embedding(" "),
+                    doc_ids=[doc_id],
+                    filters=filters,
+                    similarity_top_k=Constants.TOP_K,
+                )
+            except Exception as e:
+                self.tool.stream_log(
+                    f"Error while building vector DB query: {e}", level=LogLevel.ERROR
+                )
+                raise VectorDBError(
+                    f"Failed to construct query for {vector_db}: {e}", actual_err=e
+                )
+            try:
+                n: VectorStoreQueryResult = vector_db.query(query=q)
+                if len(n.nodes) > 0:
+                    self.tool.stream_log(f"Found {len(n.nodes)} nodes for {doc_id}")
+                    all_text = ""
+                    for node in n.nodes:
+                        all_text += node.get_content()
+                    return all_text
+                else:
+                    self.tool.stream_log(f"No nodes found for {doc_id}")
+                    return None
+            except Exception as e:
+                self.tool.stream_log(
+                    f"Error while executing vector DB query: {e}", level=LogLevel.ERROR
+                )
+                raise VectorDBError(
+                    f"Failed to execute query on {vector_db}: {e}", actual_err=e
+                )
         finally:
-            # Close connection only once at the end
             vector_db.close()
 
     @log_elapsed(operation="EXTRACTION")

--- a/src/unstract/sdk/index.py
+++ b/src/unstract/sdk/index.py
@@ -72,10 +72,10 @@ class Index:
         )
 
         try:
-            try:
-                self.tool.stream_log(
+            self.tool.stream_log(
                     f">>> Querying '{vector_db_instance_id}' for {doc_id}..."
                 )
+            try:
                 doc_id_eq_filter = MetadataFilter.from_dict(
                     {
                         "key": "doc_id",


### PR DESCRIPTION
## What

Fix for premature connection closure in vector database queries affecting Qdrant and Weaviate integrations.

## Why

The vector database connection was being closed too early due to a misplaced `finally` block, causing query attempts to fail with "Cannot send a request, as the client has been closed" errors. This was affecting prompt execution in both prompt studio.

## How

- Removed the redundant `finally` block that was closing the connection prematurely
- Consolidated error handling into a single try-except-finally block
- Ensured the vector database connection remains open throughout the query execution
- Moved connection cleanup to a single `finally` block at the end of the function

All the above changes are made in index.py

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
