### PR TITLE
passing file execution id from backend to tools

### DIFF
--- a/src/unstract/sdk/constants.py
+++ b/src/unstract/sdk/constants.py
@@ -127,6 +127,7 @@ class MetadataKey:
     SOURCE_HASH = "source_hash"
     WORKFLOW_ID = "workflow_id"
     EXECUTION_ID = "execution_id"
+    FILE_EXECUTION_ID = "file_execution_id"
     ORG_ID = "organization_id"
     TOOL_META = "tool_metadata"
     TOOL_NAME = "tool_name"
@@ -168,3 +169,10 @@ class MimeType:
     PDF = "application/pdf"
     TEXT = "text/plain"
     JSON = "application/json"
+
+
+class UsageKwargs:
+    RUN_ID = "run_id"
+    FILE_NAME = "file_name"
+    WORKFLOW_ID = "workflow_id"
+    EXECUTION_ID = "execution_id"

--- a/src/unstract/sdk/tool/base.py
+++ b/src/unstract/sdk/tool/base.py
@@ -86,12 +86,11 @@ class BaseTool(ABC, StreamMixin):
         if parsed_args.command not in Command.static_commands():
             tool._exec_metadata = tool._get_exec_metadata()
             tool.workflow_id = tool._exec_metadata.get(MetadataKey.WORKFLOW_ID)
-            tool.execution_id = tool._exec_metadata.get(MetadataKey.EXECUTION_ID)
-            tool.execution_id = tool._exec_metadata.get(MetadataKey.EXECUTION_ID)
+            tool.execution_id = tool._exec_metadata.get(MetadataKey.EXECUTION_ID, "")
             tool.file_execution_id = tool._exec_metadata.get(
-                MetadataKey.FILE_EXECUTION_ID
+                MetadataKey.FILE_EXECUTION_ID, ""
             )
-            tool.source_file_name = tool._exec_metadata.get(MetadataKey.SOURCE_NAME)
+            tool.source_file_name = tool._exec_metadata.get(MetadataKey.SOURCE_NAME, "")
             tool.org_id = tool._exec_metadata.get(MetadataKey.ORG_ID)
         return tool
 

--- a/src/unstract/sdk/tool/base.py
+++ b/src/unstract/sdk/tool/base.py
@@ -39,6 +39,8 @@ class BaseTool(ABC, StreamMixin):
         self.variables = ToolConfigHelper.variables()
         self.workflow_id = ""
         self.execution_id = ""
+        self.file_execution_id = ""
+        self.source_file_name = ""
         self.org_id = ""
         self._exec_metadata = {}
         self.filestorage_provider = None
@@ -85,6 +87,11 @@ class BaseTool(ABC, StreamMixin):
             tool._exec_metadata = tool._get_exec_metadata()
             tool.workflow_id = tool._exec_metadata.get(MetadataKey.WORKFLOW_ID)
             tool.execution_id = tool._exec_metadata.get(MetadataKey.EXECUTION_ID)
+            tool.execution_id = tool._exec_metadata.get(MetadataKey.EXECUTION_ID)
+            tool.file_execution_id = tool._exec_metadata.get(
+                MetadataKey.FILE_EXECUTION_ID
+            )
+            tool.source_file_name = tool._exec_metadata.get(MetadataKey.SOURCE_NAME)
             tool.org_id = tool._exec_metadata.get(MetadataKey.ORG_ID)
         return tool
 


### PR DESCRIPTION
## What

- Update the execution metadata with file_execution id

### Note:

- The transition from `run_id` to `file_execution_id` will be implemented incrementally. In some instances, the term `run_id` will be retained to minimize confusion during the review process due to the large number of touchpoints.

## Why

- Need to be added to get it in tools

## How

- By passing it from backend 

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/1065

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
