### PR TITLE
Fix arg name in mime_type() to path

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,5 @@
-__version__ = "0.55.0rc2"
+__version__ = "0.55.0rc3"
+
 
 def get_sdk_version():
     """Returns the SDK version."""

--- a/src/unstract/sdk/adapters/x2text/helper.py
+++ b/src/unstract/sdk/adapters/x2text/helper.py
@@ -73,7 +73,7 @@ class UnstructuredHelper:
             if not local_storage.exists(input_file_path):
                 fs.download(from_path=input_file_path, to_path=input_file_path)
             with open(input_file_path, "rb") as input_f:
-                mime_type = local_storage.mime_type(input_file=input_file_path)
+                mime_type = local_storage.mime_type(path=input_file_path)
                 files = {"file": (input_file_path, input_f, mime_type)}
                 response = UnstructuredHelper.make_request(
                     unstructured_adapter_config=unstructured_adapter_config,


### PR DESCRIPTION
## What

File storage API mime_type() used in x2text for unstructure io was using a wrong argument name.

## Why

Typo error

## How

Pass the right arg name

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Extraction and answer prompt using unstructure io enterprise adapter

## Screenshots

![image](https://github.com/user-attachments/assets/e5e0d237-23a1-4b28-bac9-104075ce5e78)


## Checklist

I have read and understood the [Contribution Guidelines]().
