### PR TITLE
[FIX] Support walk() in file storage

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,5 @@
-__version__ = "0.55.0rc2"
+__version__ = "0.55.0rc3"
+
 
 def get_sdk_version():
     """Returns the SDK version."""

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.56.0rc1"
+__version__ = "0.56.0rc2"
 
 
 def get_sdk_version():

--- a/src/unstract/sdk/adapters/x2text/helper.py
+++ b/src/unstract/sdk/adapters/x2text/helper.py
@@ -73,7 +73,7 @@ class UnstructuredHelper:
             if not local_storage.exists(input_file_path):
                 fs.download(from_path=input_file_path, to_path=input_file_path)
             with open(input_file_path, "rb") as input_f:
-                mime_type = local_storage.mime_type(input_file=input_file_path)
+                mime_type = local_storage.mime_type(path=input_file_path)
                 files = {"file": (input_file_path, input_f, mime_type)}
                 response = UnstructuredHelper.make_request(
                     unstructured_adapter_config=unstructured_adapter_config,

--- a/src/unstract/sdk/file_storage/impl.py
+++ b/src/unstract/sdk/file_storage/impl.py
@@ -399,5 +399,6 @@ class FileStorage(FileStorageInterface):
         Returns:
             Iterator containing the list of files and folders
         """
+        # Invalidating cache explicitly to avoid any stale listing
         self.fs.invalidate_cache(path=path)
         return self.fs.walk(path, maxdepth=max_depth, topdown=topdown)

--- a/src/unstract/sdk/file_storage/impl.py
+++ b/src/unstract/sdk/file_storage/impl.py
@@ -383,3 +383,21 @@ class FileStorage(FileStorageInterface):
             file_type = filetype.guess(sample_contents)
             file_extension = file_type.EXTENSION
         return file_extension
+
+    def walk(self, path: str, max_depth=None, topdown=True):
+        """Walks the dir in the path and returns the list of files/dirs.
+
+        Args:
+            path (str): Root to recurse into
+            maxdepth (int): Maximum recursion depth. None means limitless,
+            but not recommended
+                on link-based file-systems.
+            topdown (bool): Whether to walk the directory tree from the top
+            downwards or from
+                the bottom upwards.
+
+        Returns:
+            Iterator containing the list of files and folders
+        """
+        self.fs.invalidate_cache(path=path)
+        return self.fs.walk(path, maxdepth=max_depth, topdown=topdown)

--- a/src/unstract/sdk/file_storage/interface.py
+++ b/src/unstract/sdk/file_storage/interface.py
@@ -125,3 +125,7 @@ class FileStorageInterface(ABC):
     @abstractmethod
     def guess_extension(self, path: str) -> str:
         pass
+
+    @abstractmethod
+    def walk(self, path: str):
+        pass

--- a/tests/test_file_storage.py
+++ b/tests/test_file_storage.py
@@ -771,3 +771,72 @@ def test_get_storage(storage_type, env_name, expected):
     file_storage = EnvHelper.get_storage(storage_type, env_name)
     assert file_storage.provider == expected
     print(file_storage)
+
+
+@pytest.mark.parametrize(
+    "storage_type, env_name, path",
+    [
+        (
+            StorageType.PERMANENT,
+            "TEST_PERMANENT_STORAGE",
+            "fsspec-test",
+        ),
+        (
+            StorageType.SHARED_TEMPORARY,
+            "TEST_TEMPORARY_STORAGE",
+            "unstract/execution/mock_org/"
+            "13484b52-2127-48c2-b1a3-b517365346c3/"
+            "39fcdcba-90bb-44ce-9446-67253adcb4d7/COPY_TO_FOLDER",
+        ),
+    ],
+)
+def test_dir_walk(storage_type, env_name, path):
+    file_storage = EnvHelper.get_storage(storage_type, env_name)
+    try:
+        root, dirs, files = next(file_storage.walk(path))
+    except StopIteration:
+        return []
+    for dir_name in dirs:
+        print(dir_name)
+    for file_name in files:
+        print(file_name)
+    if storage_type == StorageType.PERMANENT:
+        assert len(files) > 0
+    elif storage_type == StorageType.SHARED_TEMPORARY:
+        assert len(files) == 0
+
+
+def list_print_dir(file_storage, path, iter_num):
+    print(f"PATH: {path}")
+    print(f"\nItertion: {iter_num}")
+    try:
+        root, dirs, files = next(file_storage.walk(path))
+    except StopIteration:
+        return []
+    for dir_name in dirs:
+        print(dir_name)
+    for file_name in files:
+        print(file_name)
+    print(f"Files: {files}")
+
+
+@pytest.mark.parametrize(
+    "storage_type, env_name, path",
+    [
+        (
+            StorageType.SHARED_TEMPORARY,
+            "TEST_TEMPORARY_STORAGE",
+            "unstract/execution/mock_org/"
+            "13484b52-2127-48c2-b1a3-b517365346c3/b"
+            "f7b3d81-d0aa-4e9e-883d-25dd0f3a6466/COPY_TO_FOLDER",
+        ),
+    ],
+)
+def test_dir_ls(storage_type, env_name, path):
+    new_file = os.path.join(path, "tmp.txt")
+    file_storage = EnvHelper.get_storage(storage_type, env_name)
+    if file_storage.exists(new_file):
+        file_storage.rm(new_file)
+    list_print_dir(file_storage, path, "1")
+    file_storage.write(new_file, "w", data="Hello")
+    list_print_dir(file_storage, path, "2")


### PR DESCRIPTION
## What

Add an API for walk as an equivalent for os.walk

## Why

Connectors require walk functionality to list the files and copy them over

## How

Using fsspec walk()

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-2044

## Dependencies Versions / Env Variables

- NA

## Notes on Testing

... 

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
