### PR TITLE
feat: Added link to bedrock supported models docs

### DIFF
--- a/src/unstract/sdk/adapters/llm/bedrock/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/llm/bedrock/src/static/json_schema.json
@@ -19,7 +19,7 @@
       "type": "string",
       "title": "Model",
       "default": "amazon.titan-text-express-v1",
-      "description": "Model name. Refer to Bedrock's documentation for the list of available models."
+      "description": "Model name. Refer to [Bedrock's documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) for the list of available models."
     },
     "aws_access_key_id": {
       "type": "string",


### PR DESCRIPTION
## What

- Added link to bedrock's docs for listing supported models
- Not bumping version to let this go in with any other change

## Why

- To help users add / refer models easily

## Notes on Testing


## Screenshots

![image](https://github.com/user-attachments/assets/f093309c-99e1-4a75-b475-cf17bdee217d)

## Checklist

I have read and understood the [Contribution Guidelines]().
