### PR TITLE
Support credentials to be empty in local filestorage

### DIFF
--- a/src/unstract/sdk/file_storage/env_helper.py
+++ b/src/unstract/sdk/file_storage/env_helper.py
@@ -36,7 +36,7 @@ class EnvHelper:
             provider = FileStorageProvider(
                 file_storage_creds[CredentialKeyword.PROVIDER]
             )
-            credentials = file_storage_creds.get(CredentialKeyword.CREDENTIALS, "{}")
+            credentials = file_storage_creds.get(CredentialKeyword.CREDENTIALS, {})
             if storage_type == StorageType.PERMANENT:
                 file_storage = PermanentFileStorage(provider=provider, **credentials)
             elif storage_type == StorageType.SHARED_TEMPORARY:

--- a/src/unstract/sdk/file_storage/permanent.py
+++ b/src/unstract/sdk/file_storage/permanent.py
@@ -13,7 +13,6 @@ class PermanentFileStorage(FileStorage):
     SUPPORTED_FILE_STORAGE_TYPES = [
         FileStorageProvider.GCS.value,
         FileStorageProvider.S3.value,
-        FileStorageProvider.AZURE.value,
         FileStorageProvider.LOCAL.value,
     ]
 

--- a/tests/sample.env
+++ b/tests/sample.env
@@ -27,3 +27,4 @@ FILE_STORAGE_LOCAL='{"auto_mkdir": True}'
 
 TEST_PERMANENT_STORAGE='{"provider": "gcs", "credentials": {"token": "/path/to/google/creds.json"}}'
 TEST_TEMPORARY_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "xxxx", "secret": "xxxx"}}'
+TEST_LOCAL_STORAGE='{"provider":"local"}'

--- a/tests/test_file_storage.py
+++ b/tests/test_file_storage.py
@@ -765,6 +765,11 @@ def test_glob(file_storage, folder_path, expected_result):
             "TEST_TEMPORARY_STORAGE",
             FileStorageProvider.MINIO,
         ),
+        (
+            StorageType.PERMANENT,
+            "TEST_LOCAL_STORAGE",
+            FileStorageProvider.LOCAL,
+        ),
     ],
 )
 def test_get_storage(storage_type, env_name, expected):


### PR DESCRIPTION
## What

Support credentials to be empty in local filestorage

## Why

When local filestorage is configured as  TEST_LOCAL_STORAGE='{"provider":"local"}' in the env, the existing helper function errors out. This behaviour needs to be fixed

## How

Fixing the default for credentials to be dict 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Test cases added for the same.

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
