### PR TITLE
fix: Suppress noisy logs from tool's libs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ ignore = [
     "D104",   # Missing docstring in public package
     "D103",   # Missing docstring in public function
     "D106",   # Missing docstring in public nested class
+    "D417",   # Missing argument description in the docstring
     "ANN101", # Missing type annotation for self
     "ANN102", # Missing type annotation for cls
 ]

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,6 +1,6 @@
-__version__ = "v0.70.0"
+__version__ = "v0.70.1"
 
 
-def get_sdk_version():
+def get_sdk_version() -> str:
     """Returns the SDK version."""
     return __version__


### PR DESCRIPTION
## What

- Set tool lib's logging level to `WARNING` for noisy libs

## Why

- To better debug tool logs

## How

- Updated lib's log levels while configuring the tool's logger


## Notes on Testing

- Tested by running the tool locally

## Screenshots

![image](https://github.com/user-attachments/assets/6e71359b-b86b-44e7-a908-ae8992e61f02)
## Checklist

I have read and understood the [Contribution Guidelines]().
