### PR TITLE
[FIX] Include support for tokens and costs for AWS Bedrock models

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.73.0"
+__version__ = "v0.73.1"
 
 
 def get_sdk_version() -> str:

--- a/src/unstract/sdk/utils/token_counter.py
+++ b/src/unstract/sdk/utils/token_counter.py
@@ -95,11 +95,13 @@ class TokenCounter:
             "prompt_tokens",
             "input_tokens",
             "prompt_eval_count",
+            "inputTokens",
         )
         possible_output_keys = (
             "completion_tokens",
             "output_tokens",
             "eval_count",
+            "outputTokens",
         )
 
         prompt_tokens = 0


### PR DESCRIPTION
## What

Added support for tokens and costs for aws bedrock LLM models

## Why
 
After the migration from `Bedrock` to `BedrockConverse` the tokens and cost displayed was not available.

## How

Added the parameters `inputTokens` and `outputTokens` to `token_counter.py`

## Relevant Docs

-

## Related Issues or PRs

- UN-2472-costs-and-tokens-are-not-displayed-for-bedrock-llm-adapters

## Dependencies Versions / Env Variables

-

## Notes on Testing

Tested the results in prompt-service for different aws bedrock models

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
