### PR TITLE
UN-2427 [FEAT]: Added Get llm profile function to get the profile details.

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.73.2"
+__version__ = "v0.74.0"
 
 
 def get_sdk_version() -> str:

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.73.1"
+__version__ = "v0.73.2"
 
 
 def get_sdk_version() -> str:

--- a/src/unstract/sdk/constants.py
+++ b/src/unstract/sdk/constants.py
@@ -40,6 +40,7 @@ class AdapterKeys:
 
 class PromptStudioKeys:
     PROMPT_REGISTRY_ID = "prompt_registry_id"
+    LLM_PROFILE_ID = "llm_profile_id"
 
 
 class ConnectorType:
@@ -133,6 +134,7 @@ class MetadataKey:
     ELAPSED_TIME = "elapsed_time"
     OUTPUT = "output"
     OUTPUT_TYPE = "output_type"
+    LLM_PROFILE_ID = "llm_profile_id"
 
 
 class ToolSettingsKey:

--- a/src/unstract/sdk/platform.py
+++ b/src/unstract/sdk/platform.py
@@ -182,3 +182,22 @@ class PlatformHelper(PlatformBase):
             headers=None,
             method="GET",
         )
+
+    def get_llm_profile(self, llm_profile_id: str) -> dict[str, Any]:
+        """Get llm profile by the help of unstract DB tool.
+
+        Args:
+            llm_profile_id (str): ID of the llm_profile_id
+        Required env variables:
+            PLATFORM_HOST: Host of platform service
+            PLATFORM_PORT: Port of platform service
+        """
+        query_params = {PromptStudioKeys.LLM_PROFILE_ID: llm_profile_id}
+        return self._call_service(
+            url_path="llm_profile_instance",
+            payload=None,
+            params=query_params,
+            headers=None,
+            method="GET",
+        )
+        

--- a/src/unstract/sdk/tool/base.py
+++ b/src/unstract/sdk/tool/base.py
@@ -93,6 +93,7 @@ class BaseTool(ABC, StreamMixin):
             tool.tags = tool._exec_metadata.get(MetadataKey.TAGS, [])
             tool.source_file_name = tool._exec_metadata.get(MetadataKey.SOURCE_NAME, "")
             tool.org_id = tool._exec_metadata.get(MetadataKey.ORG_ID)
+            tool.llm_profile_id = tool._exec_metadata.get(MetadataKey.LLM_PROFILE_ID)
         return tool
 
     def elapsed_time(self) -> float:


### PR DESCRIPTION
## What

Updated unstract-sdk to support LLM profile ID propagation for profile-based tool execution.
Key changes:
- Added profile support constants and methods for profile ID handling
- Updated SDK to support profile-based tool configuration

## Why

SDK needed enhancement to support the new profile-based tool configuration system:

**Profile Support Gap:**
- Existing SDK didn't have constants/methods for profile ID handling
- Tools needed standardized way to work with profile metadata
- Missing profile-specific configuration support



## How




## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
