### PR TITLE
 UN-2590 [DEPS] Bump jsonschema version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     # Specs and validation
-    "jsonschema>=4.18.6",
+    "jsonschema>=4.18.6,<5.0",
     "python-magic~=0.4.27",
     "python-dotenv==1.0.0",
     # Adapter changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     # Specs and validation
-    "jsonschema~=4.18.2",
+    "jsonschema>=4.18.6",
     "python-magic~=0.4.27",
     "python-dotenv==1.0.0",
     # Adapter changes

--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.74.0"
+__version__ = "v0.75.0"
 
 
 def get_sdk_version() -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -4283,7 +4283,7 @@ requires-dist = [
     { name = "filetype", specifier = "~=1.2.0" },
     { name = "gcsfs", marker = "extra == 'gcs'", specifier = "~=2024.10.0" },
     { name = "httpx", specifier = ">=0.25.2" },
-    { name = "jsonschema", specifier = "~=4.18.2" },
+    { name = "jsonschema", specifier = ">=4.18.6" },
     { name = "llama-index", specifier = "==0.12.39" },
     { name = "llama-index-embeddings-azure-openai", specifier = "==0.3.0" },
     { name = "llama-index-embeddings-bedrock", specifier = "==0.5.0" },


### PR DESCRIPTION
## What

- Bump version for `jsonschema` dep package
- Regenerated `uv.lock`

## Why

The current version used conflicts with a dep of upcoming SDK major version bump.

## How

Bumping `jsonschema` dep pkg version will remove version conflicts in venv thus allowing to generate `uv.lock` successfully.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this change should not break any existing features.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

- jsonschema>=4.18.6

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
