### PR TITLE
UN-2587 [FEAT] Add table processing mode support in LLM Whisperer connector

### DIFF
--- a/src/unstract/sdk/adapters/x2text/llm_whisperer_v2/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/x2text/llm_whisperer_v2/src/static/json_schema.json
@@ -33,7 +33,8 @@
         "native_text",
         "low_cost",
         "high_quality",
-        "form"
+        "form",
+        "table"
       ],
       "default": "form",
       "description": "Processing mode to use, described in the [LLMWhisperer documentation](https://docs.unstract.com/llmwhisperer/llm_whisperer/apis/llm_whisperer_text_extraction_api/#modes)."


### PR DESCRIPTION
## Summary
- Added support for "table" processing mode in LLM Whisperer v2 connector
- Updated the JSON schema to include "table" as a valid processing mode option

## Changes
- Modified `json_schema.json` to add "table" to the enum of valid processing modes
- This enables the LLM Whisperer connector to use the table processing mode for better table extraction

## Test plan
- Verify that the table processing mode is now available in the connector configuration
- Test table extraction functionality with the new mode

🤖 Generated with [Claude Code](https://claude.ai/code)