### PR TITLE
UN-2453 [FIX] Mistral AI LLM adapter test connection fix

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.76.0"
+__version__ = "v0.76.1"
 
 
 def get_sdk_version() -> str:

--- a/src/unstract/sdk/adapters/llm/mistral/src/mistral.py
+++ b/src/unstract/sdk/adapters/llm/mistral/src/mistral.py
@@ -5,7 +5,6 @@ from llama_index.core.llms import LLM
 from llama_index.llms.mistralai import MistralAI
 from llama_index.llms.mistralai.base import DEFAULT_MISTRALAI_MAX_TOKENS
 from mistralai.models import SDKError as MistralError
-
 from unstract.sdk.adapters.exceptions import AdapterError
 from unstract.sdk.adapters.llm.constants import LLMKeys
 from unstract.sdk.adapters.llm.llm_adapter import LLMAdapter

--- a/src/unstract/sdk/adapters/llm/mistral/src/mistral.py
+++ b/src/unstract/sdk/adapters/llm/mistral/src/mistral.py
@@ -52,7 +52,7 @@ class MistralLLM(LLMAdapter):
             self.config.get(Constants.MAX_RETRIES, LLMKeys.DEFAULT_MAX_RETRIES)
         )
         max_tokens = int(
-            self.config.get(Constants.MAX_RETRIES, DEFAULT_MISTRALAI_MAX_TOKENS)
+            self.config.get(Constants.MAX_TOKENS, DEFAULT_MISTRALAI_MAX_TOKENS)
         )
         try:
             llm: LLM = MistralAI(


### PR DESCRIPTION
## What

Fix for Mistral AI LLM adapter test connection not working for some models like `Mistral-medium`, `Mistral-Large` etc..

## Why

This issue was blocking one of our customers. 

## How

* Fixed the constant from which max_token were fetched. Originally they were fetched as `MAX_RETRIES`, now changed to `MAX_TOKENS`

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-2453

## Dependencies Versions / Env Variables

-

## Notes on Testing

- Tested the test connection feature with `mistral-medium` model.

## Screenshots

<img width="1445" height="1104" alt="image" src="https://github.com/user-attachments/assets/bd1897f5-3ecb-448b-b8a9-eda7e4942983" />

## Checklist

I have read and understood the [Contribution Guidelines]().
