### PR TITLE
fix: Corrected vertex AI's JSON schema

### DIFF
--- a/src/unstract/sdk/adapters/llm/vertex_ai/src/static/json_schema.json
+++ b/src/unstract/sdk/adapters/llm/vertex_ai/src/static/json_schema.json
@@ -53,7 +53,6 @@
       "title": "Safety Settings",
       "description": "Vertex AI's configurable safety filters",
       "properties": {
-        "type": "string",
         "dangerous_content": {
           "type": "string",
           "title": "Dangerous Content",

--- a/src/unstract/sdk/file_storage/helper.py
+++ b/src/unstract/sdk/file_storage/helper.py
@@ -45,7 +45,7 @@ class FileStorageHelper:
             )
             raise FileStorageError(str(e)) from e
         except Exception as e:
-            logger.error(f"Error in initialising {provider.value} " f"file system {e}")
+            logger.error(f"Error in initialising {provider.value} file system {e}")
             raise FileStorageError(str(e)) from e
         return fs
 
@@ -62,8 +62,7 @@ class FileStorageHelper:
             return fs
         except Exception as e:
             logger.error(
-                f"Error in initialising {FileStorageProvider.GCS.value}"
-                f" file system {e}"
+                f"Error in initialising {FileStorageProvider.GCS.value} file system {e}"
             )
             raise FileStorageError(str(e)) from e
 

--- a/src/unstract/sdk/file_storage/impl.py
+++ b/src/unstract/sdk/file_storage/impl.py
@@ -120,7 +120,6 @@ class FileStorage(FileStorageInterface):
         except Exception as e:
             raise FileOperationError(str(e)) from e
 
-    @skip_local_cache
     def exists(self, path: str) -> bool:
         """Checks if a file/directory path exists.
 


### PR DESCRIPTION
## What

- Fixed Vertex AI's JSON schema
- Minor error handling fix for a file storage function
## Why

- Faulty JSON schema led to error 
<img width="625" height="886" alt="image" src="https://github.com/user-attachments/assets/dfac816b-2bec-42f9-b398-6d7d6a7518da" />
- Decorator led to catching and rethrowing the same exception

## Notes on Testing

- Tested it locally
- Noticed error handling behaviour while debugging other issues

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
