### PR TITLE
UN-2805 [FEAT] Add user_data parameter for API deployment variable replacement overrides

### DIFF
--- a/src/unstract/sdk/__init__.py
+++ b/src/unstract/sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "v0.77.1"
+__version__ = "v0.77.2"
 
 
 def get_sdk_version() -> str:

--- a/src/unstract/sdk/constants.py
+++ b/src/unstract/sdk/constants.py
@@ -135,6 +135,7 @@ class MetadataKey:
     OUTPUT = "output"
     OUTPUT_TYPE = "output_type"
     LLM_PROFILE_ID = "llm_profile_id"
+    USER_DATA = "user_data"
 
 
 class ToolSettingsKey:

--- a/src/unstract/sdk/tool/base.py
+++ b/src/unstract/sdk/tool/base.py
@@ -94,6 +94,7 @@ class BaseTool(ABC, StreamMixin):
             tool.source_file_name = tool._exec_metadata.get(MetadataKey.SOURCE_NAME, "")
             tool.org_id = tool._exec_metadata.get(MetadataKey.ORG_ID)
             tool.llm_profile_id = tool._exec_metadata.get(MetadataKey.LLM_PROFILE_ID)
+            tool.user_data = tool._exec_metadata.get(MetadataKey.USER_DATA, {})
         return tool
 
     def elapsed_time(self) -> float:
@@ -132,7 +133,9 @@ class BaseTool(ABC, StreamMixin):
         base_path = self.execution_dir
         file_path = base_path / file_to_get
         if raise_err and not self.workflow_filestorage.exists(path=file_path):
-            self.stream_error_and_exit(f"{file_to_get} is missing in EXECUTION_DATA_DIR")
+            self.stream_error_and_exit(
+                f"{file_to_get} is missing in EXECUTION_DATA_DIR"
+            )
 
         return str(file_path)
 


### PR DESCRIPTION
## What

- Added USER_DATA constant to MetadataKey class for user data handling
- Updated BaseTool to extract and store user_data from execution metadata with default empty dict
- Version bump to v0.77.2

## Why

- API deployments need the ability to pass user-specific data for variable replacement overrides
- This enables dynamic configuration and personalization of tool execution based on user context
- Provides a standardized way to handle user data across the SDK

## How

- Added USER_DATA constant to the MetadataKey enumeration in constants.py
- Modified BaseTool.from_dict() to extract user_data from execution metadata
- Set default value as empty dict {} to maintain backward compatibility
- Minor formatting improvement in error message for missing execution data

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No, this PR should not break any existing features because:
- The user_data field is optional with a safe default value (empty dict)
- Existing code that doesn't provide user_data will continue to work unchanged
- The change is purely additive - no existing functionality is modified or removed
- All existing metadata handling remains the same

## Env Config

- No new environment variables required

## Related Issues or PRs

## Dependencies Versions / Env Variables

- No dependency changes
- No environment variable changes

## Notes on Testing

- Backward compatibility verified - existing tools will continue to work
- Default empty dict ensures safe handling when user_data is not provided
- Testing should verify user_data is properly extracted when present in execution metadata

## Screenshots

N/A

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

[UN-2805]: https://zipstack.atlassian.net/browse/UN-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ